### PR TITLE
fix: resolve fullscreen AX tree retrieval returning ref_count: 0

### DIFF
--- a/crates/macos/src/system/window_inventory.rs
+++ b/crates/macos/src/system/window_inventory.rs
@@ -166,8 +166,12 @@ fn ax_window_for_app(app_info: &AppInfo) -> Option<WindowInfo> {
     let window = focused_window_element(&app)
         .or_else(|| crate::tree::copy_element_attr(&app, "AXMainWindow"))
         .or_else(|| {
-            crate::tree::copy_ax_array(&app, "AXWindows")
-                .and_then(|windows| windows.into_iter().next())
+            let windows = crate::tree::copy_ax_array(&app, "AXWindows")?;
+            child_bearing_window_index(&windows, |window| {
+                crate::tree::element::count_children(window, None)
+            })
+            .map(|index| windows[index].clone())
+            .or_else(|| windows.into_iter().next())
         })?;
     if crate::tree::copy_string_attr(&window, "AXRole").as_deref() != Some("AXWindow") {
         return None;
@@ -193,6 +197,13 @@ fn ax_window_info(
         bounds: None,
         is_focused,
     }
+}
+
+fn child_bearing_window_index<T>(
+    windows: &[T],
+    mut count_children: impl FnMut(&T) -> u32,
+) -> Option<usize> {
+    windows.iter().position(|window| count_children(window) > 0)
 }
 
 type FocusedWindowIdentity = Option<(Option<String>, Option<i64>)>;

--- a/crates/macos/src/system/window_inventory_tests.rs
+++ b/crates/macos/src/system/window_inventory_tests.rs
@@ -213,6 +213,23 @@ fn ax_window_info_uses_resolved_app_identity() {
     assert_eq!(window.id, "w-7");
 }
 
+#[test]
+fn child_bearing_window_index_prefers_first_window_with_children() {
+    let windows = [0, 7, 3];
+
+    assert_eq!(
+        child_bearing_window_index(&windows, |count| *count),
+        Some(1)
+    );
+}
+
+#[test]
+fn child_bearing_window_index_returns_none_when_all_windows_are_empty() {
+    let windows = [0, 0];
+
+    assert_eq!(child_bearing_window_index(&windows, |count| *count), None);
+}
+
 fn app(name: &str, pid: i32) -> AppInfo {
     AppInfo {
         name: name.to_string(),

--- a/crates/macos/src/tree/builder.rs
+++ b/crates/macos/src/tree/builder.rs
@@ -31,8 +31,13 @@ pub fn window_element_for(pid: i32, win_title: &str) -> AXElement {
             let title = copy_string_attr(win, kAXTitleAttribute);
             if title
                 .as_deref()
-                .is_some_and(|t| t.contains(win_title) || win_title.contains(t))
+                .is_some_and(|t| !t.is_empty() && (t.contains(win_title) || win_title.contains(t)))
             {
+                return win.clone();
+            }
+        }
+        for win in &windows {
+            if count_children(win, None) > 0 {
                 return win.clone();
             }
         }

--- a/crates/macos/src/tree/builder.rs
+++ b/crates/macos/src/tree/builder.rs
@@ -23,7 +23,10 @@ pub fn window_element_for(pid: i32, win_title: &str) -> AXElement {
     if let Some(windows) = copy_ax_array(&app, kAXWindowsAttribute) {
         for win in &windows {
             let title = copy_string_attr(win, kAXTitleAttribute);
-            if title.as_deref() == Some(win_title) {
+            if title
+                .as_deref()
+                .is_some_and(|title| window_titles_are_exact_match(title, win_title))
+            {
                 return win.clone();
             }
         }
@@ -31,7 +34,7 @@ pub fn window_element_for(pid: i32, win_title: &str) -> AXElement {
             let title = copy_string_attr(win, kAXTitleAttribute);
             if title
                 .as_deref()
-                .is_some_and(|t| !t.is_empty() && (t.contains(win_title) || win_title.contains(t)))
+                .is_some_and(|title| window_titles_are_partial_match(title, win_title))
             {
                 return win.clone();
             }
@@ -47,6 +50,18 @@ pub fn window_element_for(pid: i32, win_title: &str) -> AXElement {
     }
 
     app
+}
+
+#[cfg(target_os = "macos")]
+fn window_titles_are_exact_match(candidate_title: &str, requested_title: &str) -> bool {
+    !candidate_title.is_empty() && !requested_title.is_empty() && candidate_title == requested_title
+}
+
+#[cfg(target_os = "macos")]
+fn window_titles_are_partial_match(candidate_title: &str, requested_title: &str) -> bool {
+    !candidate_title.is_empty()
+        && !requested_title.is_empty()
+        && (candidate_title.contains(requested_title) || requested_title.contains(candidate_title))
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/macos/src/tree/builder_tests.rs
+++ b/crates/macos/src/tree/builder_tests.rs
@@ -1,4 +1,7 @@
-use super::{child_attributes, redact_secure_value};
+use super::{
+    child_attributes, redact_secure_value, window_titles_are_exact_match,
+    window_titles_are_partial_match,
+};
 
 #[test]
 fn test_browser_children_use_columns() {
@@ -26,4 +29,26 @@ fn test_secure_text_value_is_redacted() {
         redact_secure_value(Some("AXTextField"), Some("visible".into())),
         Some("visible".into())
     );
+}
+
+#[test]
+fn window_title_matching_rejects_empty_titles() {
+    assert!(!window_titles_are_exact_match("", ""));
+    assert!(!window_titles_are_exact_match("Inbox", ""));
+    assert!(!window_titles_are_exact_match("", "Inbox"));
+    assert!(!window_titles_are_partial_match("Inbox", ""));
+    assert!(!window_titles_are_partial_match("", "Inbox"));
+}
+
+#[test]
+fn window_title_matching_accepts_exact_and_truncated_titles() {
+    assert!(window_titles_are_exact_match("Inbox", "Inbox"));
+    assert!(window_titles_are_partial_match(
+        "noy4/agent-desktop: Native desktop automation",
+        "noy4/agent-desktop"
+    ));
+    assert!(window_titles_are_partial_match(
+        "noy4/agent-desktop: Native desk...",
+        "noy4/agent-desktop: Native desk"
+    ));
 }


### PR DESCRIPTION
# Fix Chromium fullscreen AX tree retrieval (ref_count: 0)

## Summary
Fixes an issue where `agent-desktop snapshot` returns an empty accessibility tree (`ref_count: 0`) for Chromium browsers in macOS native fullscreen mode.

## Problem
Window selection fails due to:
1. **Title Truncation**: CoreGraphics truncates titles with `…`, while the AX API returns the full title, breaking partial matches.
2. **Empty String Match**: `win_title.contains("")` is always true, causing false matches with placeholder windows.
3. **Flawed Fallback**: Falls back to the first window in `kAXWindowsAttribute`, which is often an empty placeholder (`children = 0`) in fullscreen Chromium.

## Context: Split Mode Behavior
In split mode, multiple windows are reported for the same app, including generic or truncated titles, making robust selection critical.

Example `list-windows` output in split mode:
```json
[
  {"app_name":"Brave Browser","id":"w-20817","is_focused":false,"pid":12858,"title":"Brave Browser"},
  {"app_name":"Brave Browser","id":"w-20812","is_focused":false,"pid":12858,"title":"noy4/agent-desktop: Native desk…nd deterministic element refs."},
  {"app_name":"Code","id":"w-22373","is_focused":false,"pid":4904,"title":"Code"},
  {"app_name":"Code","id":"w-20391","is_focused":true,"pid":4904,"title":"builder.rs (Index) (builder.rs) — agent-desktop"}
]
```

## Solution
Updated `window_element_for` in `crates/macos/src/tree/builder.rs`:
1. Added `!t.is_empty()` to partial title matching to prevent false positives.
2. Added a fallback loop that selects the first window with `children > 0` (using the lightweight `count_children` API), reliably targeting the active window.

## Testing
Verified on fullscreen Brave Browser:
- Before: `ref_count: 0`
- After: `ref_count: 212` (with `--skeleton -i`)