### PR TITLE
feat: add ad_abi_version and ad_init ABI handshake

### DIFF
--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -6,6 +6,20 @@
 #include <stddef.h>
 
 /**
+ * The major ABI version of this build of `libagent_desktop_ffi`.
+ *
+ * Version-bump rule: increment this constant (and update the header via
+ * `scripts/update-ffi-header.sh`) whenever a breaking change is made to the
+ * C ABI — a removed or incompatibly-changed `ad_*` symbol, or a layout
+ * change to any `repr(C)` struct. Additive changes (new `ad_*` symbols, new
+ * error codes) do **not** require a bump. Consumers must call `ad_init` with
+ * the major they compiled against before making any adapter calls; a mismatch
+ * returns `AD_RESULT_ERR_INVALID_ARGS` so they can refuse gracefully rather
+ * than corrupt memory.
+ */
+#define AD_ABI_VERSION_MAJOR 1
+
+/**
  * Maximum byte length (excluding the NUL terminator) accepted for any
  * foreign C string. Bounds both the terminator scan and the resulting
  * allocation, so a missing NUL or a hostile caller cannot walk arbitrary
@@ -534,6 +548,26 @@ typedef struct AdWindowOp {
   double x;
   double y;
 } AdWindowOp;
+
+/**
+ * Returns the packed ABI major version of this dylib build.
+ *
+ * A consumer should compare this to `AD_ABI_VERSION_MAJOR` from the header it
+ * compiled against. If they differ, call nothing further — the ABI is
+ * incompatible.
+ */
+uint32_t ad_abi_version(void);
+
+/**
+ * Validates that the consumer's expected ABI major matches this dylib.
+ *
+ * Call once after `dlopen` / `LoadLibrary`, before any adapter call.
+ * Returns `AD_RESULT_OK` when `expected_major == AD_ABI_VERSION_MAJOR`.
+ * Returns `AD_RESULT_ERR_INVALID_ARGS` with a diagnostic last-error when the
+ * version does not match, so the consumer can refuse to proceed rather than
+ * crash with an incompatible ABI.
+ */
+AdResult ad_init(uint32_t expected_major);
 
 /**
  * # Safety

--- a/crates/ffi/src/abi_version.rs
+++ b/crates/ffi/src/abi_version.rs
@@ -1,0 +1,47 @@
+use crate::error::{AdResult, set_last_error_static};
+use crate::ffi_try::trap_panic;
+use std::ffi::CStr;
+
+/// The major ABI version of this build of `libagent_desktop_ffi`.
+///
+/// Version-bump rule: increment this constant (and update the header via
+/// `scripts/update-ffi-header.sh`) whenever a breaking change is made to the
+/// C ABI — a removed or incompatibly-changed `ad_*` symbol, or a layout
+/// change to any `repr(C)` struct. Additive changes (new `ad_*` symbols, new
+/// error codes) do **not** require a bump. Consumers must call `ad_init` with
+/// the major they compiled against before making any adapter calls; a mismatch
+/// returns `AD_RESULT_ERR_INVALID_ARGS` so they can refuse gracefully rather
+/// than corrupt memory.
+pub const AD_ABI_VERSION_MAJOR: u32 = 1;
+
+static MISMATCH_MESSAGE: &CStr =
+    c"ABI major version mismatch: recompile against the installed header";
+
+/// Returns the packed ABI major version of this dylib build.
+///
+/// A consumer should compare this to `AD_ABI_VERSION_MAJOR` from the header it
+/// compiled against. If they differ, call nothing further — the ABI is
+/// incompatible.
+#[unsafe(no_mangle)]
+pub extern "C" fn ad_abi_version() -> u32 {
+    AD_ABI_VERSION_MAJOR
+}
+
+/// Validates that the consumer's expected ABI major matches this dylib.
+///
+/// Call once after `dlopen` / `LoadLibrary`, before any adapter call.
+/// Returns `AD_RESULT_OK` when `expected_major == AD_ABI_VERSION_MAJOR`.
+/// Returns `AD_RESULT_ERR_INVALID_ARGS` with a diagnostic last-error when the
+/// version does not match, so the consumer can refuse to proceed rather than
+/// crash with an incompatible ABI.
+#[unsafe(no_mangle)]
+pub extern "C" fn ad_init(expected_major: u32) -> AdResult {
+    trap_panic(|| {
+        if expected_major == AD_ABI_VERSION_MAJOR {
+            AdResult::Ok
+        } else {
+            set_last_error_static(AdResult::ErrInvalidArgs, MISMATCH_MESSAGE);
+            AdResult::ErrInvalidArgs
+        }
+    })
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -14,6 +14,7 @@
 //!
 //! Operations exempt from the guard (safe from any thread):
 //!
+//! - `ad_abi_version` / `ad_init` (no adapter, no AX/Cocoa state)
 //! - `ad_adapter_create` / `ad_adapter_destroy`
 //! - `ad_last_error_*` readers
 //! - `ad_check_permissions` (process-wide query, no AX/Cocoa state)
@@ -41,7 +42,7 @@
 //! any number of subsequent successful calls on the same thread; only
 //! the next *failing* call rotates it. Matches POSIX `errno` semantics.
 
-pub mod abi_version;
+pub(crate) mod abi_version;
 pub(crate) mod actions;
 pub(crate) mod adapter;
 pub(crate) mod apps;

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -41,6 +41,7 @@
 //! any number of subsequent successful calls on the same thread; only
 //! the next *failing* call rotates it. Matches POSIX `errno` semantics.
 
+pub mod abi_version;
 pub(crate) mod actions;
 pub(crate) mod adapter;
 pub(crate) mod apps;
@@ -59,6 +60,7 @@ pub(crate) mod tree;
 pub mod types;
 pub(crate) mod windows;
 
+pub use abi_version::AD_ABI_VERSION_MAJOR;
 pub use adapter::AdAdapter;
 pub use error::AdResult;
 pub use types::action::AdAction;

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -2,10 +2,62 @@ mod common;
 
 use common::{
     AdAppList, AdFindQuery, AdNativeHandle, AdResult, AdWindowInfo, AdWindowList, CStr,
-    ad_adapter_create, ad_adapter_destroy, ad_app_list_count, ad_app_list_free, ad_app_list_get,
-    ad_check_permissions, ad_find, ad_free_handle, ad_last_error_code, ad_last_error_message,
-    ad_list_apps, ad_list_windows, ad_window_list_count, ad_window_list_free, with_adapter,
+    ad_abi_version, ad_adapter_create, ad_adapter_destroy, ad_app_list_count, ad_app_list_free,
+    ad_app_list_get, ad_check_permissions, ad_find, ad_free_handle, ad_init, ad_last_error_code,
+    ad_last_error_message, ad_list_apps, ad_list_windows, ad_window_list_count,
+    ad_window_list_free, with_adapter,
 };
+
+#[test]
+fn abi_version_matches_rust_constant() {
+    unsafe {
+        assert_eq!(
+            ad_abi_version(),
+            agent_desktop_ffi::AD_ABI_VERSION_MAJOR,
+            "ad_abi_version() must equal AD_ABI_VERSION_MAJOR"
+        );
+    }
+}
+
+#[test]
+fn ad_init_succeeds_with_current_major() {
+    unsafe {
+        assert_eq!(
+            ad_init(agent_desktop_ffi::AD_ABI_VERSION_MAJOR),
+            AdResult::Ok
+        );
+    }
+}
+
+#[test]
+fn ad_init_rejects_future_major_and_sets_last_error() {
+    unsafe {
+        let rc = ad_init(agent_desktop_ffi::AD_ABI_VERSION_MAJOR + 1);
+        assert_eq!(rc, AdResult::ErrInvalidArgs);
+        let msg = ad_last_error_message();
+        assert!(
+            !msg.is_null(),
+            "last-error message must be non-null after mismatch"
+        );
+        let _ = CStr::from_ptr(msg).to_string_lossy();
+        assert_eq!(ad_last_error_code(), AdResult::ErrInvalidArgs);
+    }
+}
+
+#[test]
+fn ad_init_rejects_zero_major_and_sets_last_error() {
+    unsafe {
+        let rc = ad_init(0);
+        assert_eq!(rc, AdResult::ErrInvalidArgs);
+        let msg = ad_last_error_message();
+        assert!(
+            !msg.is_null(),
+            "last-error message must be non-null after zero-major mismatch"
+        );
+        let _ = CStr::from_ptr(msg).to_string_lossy();
+        assert_eq!(ad_last_error_code(), AdResult::ErrInvalidArgs);
+    }
+}
 
 #[test]
 fn null_adapter_rejected_without_ub() {

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -11,6 +11,9 @@ pub use std::ffi::CStr;
 pub use std::os::raw::c_char;
 
 unsafe extern "C" {
+    pub fn ad_abi_version() -> u32;
+    pub fn ad_init(expected_major: u32) -> AdResult;
+
     pub fn ad_ref_entry_size() -> usize;
     pub fn ad_action_size() -> usize;
     pub fn ad_action_step_size() -> usize;


### PR DESCRIPTION
Adds the load-time ABI compatibility handshake: `ad_abi_version() -> u32` (the only mechanism a dlopen consumer can use to detect a header/dylib mismatch) and `ad_init(expected_major)` which fails closed (`ErrInvalidArgs`) on mismatch. `AD_ABI_VERSION_MAJOR` is emitted into the header by cbindgen from the single Rust const.

---
Stacked on #67 (FFI header foundation). **Do not merge ahead of its base.** Phase A · Wave 1.

Gated locally against the full CI contract before opening: `fmt --check`, `clippy --locked -D warnings`, `cargo test --locked --lib --workspace` + `-p agent-desktop` + `-p agent-desktop-ffi --tests` (all 0 failed), and `ci` + `release-ffi` profile builds. Header carries the 19 `_Static_assert` guards + this unit's symbol.