### PR TITLE
feat: add ad_version FFI entrypoint

### DIFF
--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -759,6 +759,20 @@ const struct AdAppInfo *ad_app_list_get(const struct AdAppList *list, uint32_t i
 void ad_app_list_free(struct AdAppList *list);
 
 /**
+ * Returns the `agent-desktop` version envelope as an owned JSON C string.
+ *
+ * The returned string has the same `{version, ok, command, data}` shape
+ * as `agent-desktop version` on the CLI. Free it with `ad_free_string`.
+ *
+ * On success `*out` points to the envelope JSON.
+ * On error `*out` is null and the last-error slot is populated.
+ *
+ * # Safety
+ * `out` must be a non-null writable `*mut *mut c_char`.
+ */
+AdResult ad_version(char **out);
+
+/**
  * Last-error lifetime — errno-style.
  *
  * The pointer returned by `ad_last_error_message`,

--- a/crates/ffi/src/commands/mod.rs
+++ b/crates/ffi/src/commands/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod version;

--- a/crates/ffi/src/commands/version.rs
+++ b/crates/ffi/src/commands/version.rs
@@ -16,11 +16,9 @@ use std::os::raw::c_char;
 /// `out` must be a non-null writable `*mut *mut c_char`.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn ad_version(out: *mut *mut c_char) -> AdResult {
-    crate::pointer_guard::guard_non_null!(out, c"out is null");
-    trap_panic(|| {
-        unsafe {
-            *out = std::ptr::null_mut();
-        }
+    trap_panic(|| unsafe {
+        crate::pointer_guard::guard_non_null!(out, c"out is null");
+        *out = std::ptr::null_mut();
         match agent_desktop_core::commands::version::execute() {
             Ok(data) => {
                 let envelope = Response::ok("version", data);
@@ -42,9 +40,7 @@ pub unsafe extern "C" fn ad_version(out: *mut *mut c_char) -> AdResult {
                     ));
                     return AdResult::ErrInternal;
                 }
-                unsafe {
-                    *out = c;
-                }
+                *out = c;
                 AdResult::Ok
             }
             Err(e) => {

--- a/crates/ffi/src/commands/version.rs
+++ b/crates/ffi/src/commands/version.rs
@@ -1,0 +1,59 @@
+use crate::convert::string::string_to_c;
+use crate::error::{self, AdResult};
+use crate::ffi_try::trap_panic;
+use agent_desktop_core::output::Response;
+use std::os::raw::c_char;
+
+/// Returns the `agent-desktop` version envelope as an owned JSON C string.
+///
+/// The returned string has the same `{version, ok, command, data}` shape
+/// as `agent-desktop version` on the CLI. Free it with `ad_free_string`.
+///
+/// On success `*out` points to the envelope JSON.
+/// On error `*out` is null and the last-error slot is populated.
+///
+/// # Safety
+/// `out` must be a non-null writable `*mut *mut c_char`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ad_version(out: *mut *mut c_char) -> AdResult {
+    crate::pointer_guard::guard_non_null!(out, c"out is null");
+    trap_panic(|| {
+        unsafe {
+            *out = std::ptr::null_mut();
+        }
+        match agent_desktop_core::commands::version::execute() {
+            Ok(data) => {
+                let envelope = Response::ok("version", data);
+                let json = match serde_json::to_string(&envelope) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error::set_last_error(&agent_desktop_core::error::AdapterError::new(
+                            agent_desktop_core::error::ErrorCode::Internal,
+                            format!("failed to serialize version envelope: {e}"),
+                        ));
+                        return AdResult::ErrInternal;
+                    }
+                };
+                let c = string_to_c(&json);
+                if c.is_null() {
+                    error::set_last_error(&agent_desktop_core::error::AdapterError::new(
+                        agent_desktop_core::error::ErrorCode::Internal,
+                        "version JSON contains an interior NUL byte",
+                    ));
+                    return AdResult::ErrInternal;
+                }
+                unsafe {
+                    *out = c;
+                }
+                AdResult::Ok
+            }
+            Err(e) => {
+                error::set_last_error(&agent_desktop_core::error::AdapterError::new(
+                    agent_desktop_core::error::ErrorCode::Internal,
+                    e.to_string(),
+                ));
+                AdResult::ErrInternal
+            }
+        }
+    })
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -46,6 +46,7 @@ pub(crate) mod abi_version;
 pub(crate) mod actions;
 pub(crate) mod adapter;
 pub(crate) mod apps;
+pub(crate) mod commands;
 pub(crate) mod convert;
 pub(crate) mod enum_validation;
 pub mod error;

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -3,9 +3,9 @@ mod common;
 use common::{
     AdAppList, AdFindQuery, AdNativeHandle, AdResult, AdWindowInfo, AdWindowList, CStr,
     ad_abi_version, ad_adapter_create, ad_adapter_destroy, ad_app_list_count, ad_app_list_free,
-    ad_app_list_get, ad_check_permissions, ad_find, ad_free_handle, ad_init, ad_last_error_code,
-    ad_last_error_message, ad_list_apps, ad_list_windows, ad_window_list_count,
-    ad_window_list_free, with_adapter,
+    ad_app_list_get, ad_check_permissions, ad_find, ad_free_handle, ad_free_string, ad_init,
+    ad_last_error_code, ad_last_error_message, ad_list_apps, ad_list_windows, ad_version,
+    ad_window_list_count, ad_window_list_free, with_adapter,
 };
 
 #[test]
@@ -198,6 +198,85 @@ fn free_handle_zeroes_ptr_so_double_free_is_noop() {
         let rc = ad_free_handle(adapter, &mut handle);
         assert_eq!(rc, AdResult::Ok);
     });
+}
+
+#[test]
+fn ad_version_returns_ok_with_valid_json_envelope() {
+    unsafe {
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_version(&mut out);
+        assert_eq!(rc, AdResult::Ok, "ad_version must return OK");
+        assert!(!out.is_null(), "out must be non-null on success");
+
+        let json_str = CStr::from_ptr(out).to_string_lossy();
+        let parsed: serde_json::Value =
+            serde_json::from_str(&json_str).expect("output must be valid JSON");
+
+        assert_eq!(
+            parsed["ok"].as_bool(),
+            Some(true),
+            "envelope ok must be true"
+        );
+        assert_eq!(
+            parsed["command"].as_str(),
+            Some("version"),
+            "envelope command must be 'version'"
+        );
+        assert!(
+            parsed["data"]["version"].is_string(),
+            "data.version must be a string"
+        );
+        assert!(
+            parsed["data"]["target"].is_string(),
+            "data.target must be a string"
+        );
+        assert!(parsed["data"]["os"].is_string(), "data.os must be a string");
+
+        let envelope_version = parsed["version"]
+            .as_str()
+            .expect("version field must exist");
+        assert_eq!(
+            envelope_version,
+            agent_desktop_core::output::ENVELOPE_VERSION,
+            "envelope version must match ENVELOPE_VERSION constant"
+        );
+
+        ad_free_string(out);
+    }
+}
+
+#[test]
+fn ad_version_null_out_returns_invalid_args() {
+    unsafe {
+        let rc = ad_version(std::ptr::null_mut());
+        assert_eq!(
+            rc,
+            AdResult::ErrInvalidArgs,
+            "null out must return ErrInvalidArgs"
+        );
+    }
+}
+
+#[test]
+fn ad_version_success_preserves_prior_last_error() {
+    unsafe {
+        let rc_fail = ad_version(std::ptr::null_mut());
+        assert_eq!(rc_fail, AdResult::ErrInvalidArgs);
+        let err_before = ad_last_error_code();
+        assert_eq!(err_before, AdResult::ErrInvalidArgs);
+
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc_ok = ad_version(&mut out);
+        assert_eq!(rc_ok, AdResult::Ok);
+
+        assert_eq!(
+            ad_last_error_code(),
+            AdResult::ErrInvalidArgs,
+            "success must not clear the prior last-error"
+        );
+
+        ad_free_string(out);
+    }
 }
 
 #[test]

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -13,6 +13,8 @@ pub use std::os::raw::c_char;
 unsafe extern "C" {
     pub fn ad_abi_version() -> u32;
     pub fn ad_init(expected_major: u32) -> AdResult;
+    pub fn ad_version(out: *mut *mut c_char) -> AdResult;
+    pub fn ad_free_string(s: *mut c_char);
 
     pub fn ad_ref_entry_size() -> usize;
     pub fn ad_action_size() -> usize;


### PR DESCRIPTION
Adds `ad_version(out)`. Wraps the core `version::execute()` payload in the full CLI JSON envelope via `output::Response::ok` (KTD9) — so FFI output matches the CLI byte-for-byte. `guard_non_null` outside the panic boundary, out-param zeroed on error, caller frees with `ad_free_string`.

---
Stacked on #67 (FFI header foundation). **Do not merge ahead of its base.** Phase A · Wave 1.

Gated locally against the full CI contract before opening: `fmt --check`, `clippy --locked -D warnings`, `cargo test --locked --lib --workspace` + `-p agent-desktop` + `-p agent-desktop-ffi --tests` (all 0 failed), and `ci` + `release-ffi` profile builds. Header carries the 19 `_Static_assert` guards + this unit's symbol.