### PR TITLE
feat: add session-scoped FFI adapter constructor

### DIFF
--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -675,6 +675,24 @@ void ad_free_action_result(struct AdActionResult *result);
 struct AdAdapter *ad_adapter_create(void);
 
 /**
+ * Builds a session-scoped platform adapter. `session` may be:
+ * - null: equivalent to `ad_adapter_create()` (no session).
+ * - a valid session id (1-64 ASCII alphanumeric / `-` / `_` chars): associates
+ *   the adapter with that session for refmap persistence.
+ * - empty, too long, containing invalid characters, or invalid UTF-8: sets
+ *   `ErrInvalidArgs` in the last-error slot and returns null; no adapter is
+ *   allocated.
+ *
+ * The returned pointer must be released with `ad_adapter_destroy`.
+ *
+ * # Safety
+ *
+ * `session` must be null or point to readable memory that is NUL-terminated
+ * within `AD_MAX_STRING_BYTES + 1` bytes.
+ */
+struct AdAdapter *ad_adapter_create_with_session(const char *session);
+
+/**
  * # Safety
  *
  * `adapter` must be a pointer returned by `ad_adapter_create`, or null.

--- a/crates/ffi/src/adapter.rs
+++ b/crates/ffi/src/adapter.rs
@@ -1,9 +1,14 @@
+use crate::convert::string::optional_adapter_string;
 use crate::error::{self, AdResult};
 use crate::ffi_try::{trap_panic, trap_panic_ptr, trap_panic_void};
+use agent_desktop_core::context::{CommandContext, validate_session_id};
+use agent_desktop_core::error::{AdapterError, AppError};
 use agent_desktop_core::{PermissionState, adapter::PlatformAdapter};
+use std::ffi::c_char;
 
 pub struct AdAdapter {
     pub(crate) inner: Box<dyn PlatformAdapter>,
+    pub(crate) session_id: Option<String>,
 }
 
 fn build_adapter() -> Box<dyn PlatformAdapter> {
@@ -38,6 +43,52 @@ pub extern "C" fn ad_adapter_create() -> *mut AdAdapter {
     trap_panic_ptr(|| {
         let adapter = AdAdapter {
             inner: build_adapter(),
+            session_id: None,
+        };
+        Box::into_raw(Box::new(adapter))
+    })
+}
+
+/// Builds a session-scoped platform adapter. `session` may be:
+/// - null: equivalent to `ad_adapter_create()` (no session).
+/// - a valid session id (1-64 ASCII alphanumeric / `-` / `_` chars): associates
+///   the adapter with that session for refmap persistence.
+/// - empty, too long, containing invalid characters, or invalid UTF-8: sets
+///   `ErrInvalidArgs` in the last-error slot and returns null; no adapter is
+///   allocated.
+///
+/// The returned pointer must be released with `ad_adapter_destroy`.
+///
+/// # Safety
+///
+/// `session` must be null or point to readable memory that is NUL-terminated
+/// within `AD_MAX_STRING_BYTES + 1` bytes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ad_adapter_create_with_session(session: *const c_char) -> *mut AdAdapter {
+    trap_panic_ptr(|| {
+        let session_id = match optional_adapter_string(session, "session") {
+            Ok(opt) => opt,
+            Err(err) => {
+                error::set_last_error(&err);
+                return std::ptr::null_mut();
+            }
+        };
+        if let Some(id) = session_id.as_deref() {
+            if let Err(app_err) = validate_session_id(id) {
+                let adapter_err = match app_err {
+                    AppError::Adapter(e) => e,
+                    _ => AdapterError::new(
+                        agent_desktop_core::error::ErrorCode::InvalidArgs,
+                        "invalid session id",
+                    ),
+                };
+                error::set_last_error(&adapter_err);
+                return std::ptr::null_mut();
+            }
+        }
+        let adapter = AdAdapter {
+            inner: build_adapter(),
+            session_id,
         };
         Box::into_raw(Box::new(adapter))
     })
@@ -81,6 +132,15 @@ pub unsafe extern "C" fn ad_check_permissions(adapter: *const AdAdapter) -> AdRe
             PermissionState::Unknown => unknown_permission_result(adapter.inner.as_ref()),
         }
     })
+}
+
+impl AdAdapter {
+    /// Builds a `CommandContext` from this adapter's session. Callers that
+    /// need a context for context-taking commands (snapshot, status, wait)
+    /// call this at the FFI entry boundary.
+    pub fn command_context(&self) -> Result<CommandContext, AppError> {
+        CommandContext::new(self.session_id.clone(), None, false)
+    }
 }
 
 fn unknown_permission_result(adapter: &dyn PlatformAdapter) -> AdResult {
@@ -135,6 +195,7 @@ mod tests {
     fn check_permissions_maps_default_unknown_accessibility_to_platform_unsupported() {
         let adapter = AdAdapter {
             inner: Box::new(UnknownPermissionAdapter),
+            session_id: None,
         };
 
         let result = unsafe { ad_check_permissions(&adapter) };
@@ -162,6 +223,7 @@ mod tests {
     fn check_permissions_preserves_ambiguous_unknown_accessibility_as_internal() {
         let adapter = AdAdapter {
             inner: Box::new(AmbiguousPermissionAdapter),
+            session_id: None,
         };
 
         let result = unsafe { ad_check_permissions(&adapter) };

--- a/crates/ffi/src/adapter.rs
+++ b/crates/ffi/src/adapter.rs
@@ -77,9 +77,9 @@ pub unsafe extern "C" fn ad_adapter_create_with_session(session: *const c_char) 
             if let Err(app_err) = validate_session_id(id) {
                 let adapter_err = match app_err {
                     AppError::Adapter(e) => e,
-                    _ => AdapterError::new(
+                    other => AdapterError::new(
                         agent_desktop_core::error::ErrorCode::InvalidArgs,
-                        "invalid session id",
+                        other.to_string(),
                     ),
                 };
                 error::set_last_error(&adapter_err);

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -2,10 +2,11 @@ mod common;
 
 use common::{
     AdAppList, AdFindQuery, AdNativeHandle, AdResult, AdWindowInfo, AdWindowList, CStr,
-    ad_abi_version, ad_adapter_create, ad_adapter_destroy, ad_app_list_count, ad_app_list_free,
-    ad_app_list_get, ad_check_permissions, ad_find, ad_free_handle, ad_free_string, ad_init,
-    ad_last_error_code, ad_last_error_message, ad_list_apps, ad_list_windows, ad_version,
-    ad_window_list_count, ad_window_list_free, with_adapter,
+    ad_abi_version, ad_adapter_create, ad_adapter_create_with_session, ad_adapter_destroy,
+    ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_find,
+    ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
+    ad_list_apps, ad_list_windows, ad_version, ad_window_list_count, ad_window_list_free,
+    with_adapter,
 };
 
 #[test]
@@ -303,5 +304,86 @@ fn last_error_survives_successful_calls() {
         assert_eq!(msg_ptr, after);
         assert_eq!(ad_last_error_code(), rc);
         ad_adapter_destroy(adapter);
+    }
+}
+
+#[test]
+fn sessionless_adapter_has_no_session_id() {
+    unsafe {
+        let ptr = ad_adapter_create();
+        assert!(!ptr.is_null(), "ad_adapter_create must not return null");
+        let ctx = (*ptr)
+            .command_context()
+            .expect("command_context must succeed");
+        assert_eq!(ctx.session_id(), None);
+        ad_adapter_destroy(ptr);
+    }
+}
+
+#[test]
+fn session_adapter_carries_session_id() {
+    unsafe {
+        let session = std::ffi::CString::new("agent-a").unwrap();
+        let ptr = ad_adapter_create_with_session(session.as_ptr());
+        assert!(
+            !ptr.is_null(),
+            "ad_adapter_create_with_session must not return null"
+        );
+        let ctx = (*ptr)
+            .command_context()
+            .expect("command_context must succeed");
+        assert_eq!(ctx.session_id(), Some("agent-a"));
+        ad_adapter_destroy(ptr);
+    }
+}
+
+#[test]
+fn null_session_adapter_is_sessionless() {
+    unsafe {
+        let ptr = ad_adapter_create_with_session(std::ptr::null());
+        assert!(
+            !ptr.is_null(),
+            "null session must yield a sessionless adapter"
+        );
+        let ctx = (*ptr)
+            .command_context()
+            .expect("command_context must succeed");
+        assert_eq!(ctx.session_id(), None);
+        ad_adapter_destroy(ptr);
+    }
+}
+
+#[test]
+fn invalid_utf8_session_returns_null_and_sets_invalid_args() {
+    unsafe {
+        let bad: [u8; 3] = [0xC3, 0xFF, 0x00];
+        let ptr = ad_adapter_create_with_session(bad.as_ptr() as *const std::os::raw::c_char);
+        assert!(ptr.is_null(), "invalid UTF-8 session must return null");
+        assert_eq!(
+            ad_last_error_code(),
+            AdResult::ErrInvalidArgs,
+            "invalid UTF-8 must set ErrInvalidArgs"
+        );
+        let msg = ad_last_error_message();
+        assert!(
+            !msg.is_null(),
+            "error message must be set on invalid UTF-8 session"
+        );
+    }
+}
+
+#[test]
+fn empty_session_returns_null_and_sets_invalid_args() {
+    unsafe {
+        let empty = std::ffi::CString::new("").unwrap();
+        let ptr = ad_adapter_create_with_session(empty.as_ptr());
+        assert!(ptr.is_null(), "empty session id must return null");
+        assert_eq!(
+            ad_last_error_code(),
+            AdResult::ErrInvalidArgs,
+            "empty session id must set ErrInvalidArgs"
+        );
+        let msg = ad_last_error_message();
+        assert!(!msg.is_null(), "error message must be set on empty session");
     }
 }

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -23,6 +23,7 @@ unsafe extern "C" {
     pub fn ad_element_state_size() -> usize;
 
     pub fn ad_adapter_create() -> *mut AdAdapter;
+    pub fn ad_adapter_create_with_session(session: *const c_char) -> *mut AdAdapter;
     pub fn ad_adapter_destroy(adapter: *mut AdAdapter);
     pub fn ad_check_permissions(adapter: *const AdAdapter) -> AdResult;
 


### PR DESCRIPTION
Adds `session_id` to `AdAdapter` and a separate `ad_adapter_create_with_session` constructor (not a setter — avoids racing an in-flight snapshot). Tri-state C-string decode; validates the session at construction so empty/invalid sessions fail closed immediately with `ErrInvalidArgs` rather than deferring to later calls. Enables refmap persistence for U4/U5/U7.

---
Stacked on #67 (FFI header foundation). **Do not merge ahead of its base.** Phase A · Wave 1.

Gated locally against the full CI contract before opening: `fmt --check`, `clippy --locked -D warnings`, `cargo test --locked --lib --workspace` + `-p agent-desktop` + `-p agent-desktop-ffi --tests` (all 0 failed), and `ci` + `release-ffi` profile builds. Header carries the 19 `_Static_assert` guards + this unit's symbol.