### PR TITLE
feat: add ad_set_log_callback with tracing layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,6 +52,8 @@ dependencies = [
  "libc",
  "serde_json",
  "smallvec",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod roles;
 pub(crate) mod search_text;
 pub mod snapshot;
 pub mod snapshot_ref;
-pub mod trace;
+pub(crate) mod trace;
 mod window_lookup;
 
 pub use action::{
@@ -56,3 +56,4 @@ pub use permission_report::PermissionReport;
 pub use permission_state::PermissionState;
 pub use refs::{RefEntry, RefMap};
 pub use refs_store::RefStore;
+pub use trace::sanitize_trace_value;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -30,7 +30,7 @@ pub mod roles;
 pub(crate) mod search_text;
 pub mod snapshot;
 pub mod snapshot_ref;
-pub(crate) mod trace;
+pub mod trace;
 mod window_lookup;
 
 pub use action::{

--- a/crates/core/src/trace.rs
+++ b/crates/core/src/trace.rs
@@ -124,7 +124,11 @@ fn reject_loose_trace_permissions(_file: &std::fs::File) -> Result<(), AppError>
     Ok(())
 }
 
-fn sanitize_trace_value(value: Value) -> Value {
+/// Recursively redacts fields whose keys match `SENSITIVE_KEYS`. Non-sensitive
+/// fields and non-object values are left unchanged. Array elements are
+/// recursively scanned. Used by both the file-trace writer and the FFI log
+/// callback layer so that sensitive values never reach a consumer.
+pub fn sanitize_trace_value(value: Value) -> Value {
     match value {
         Value::Object(map) => Value::Object(
             map.into_iter()

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -11,6 +11,8 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 smallvec.workspace = true
 serde_json.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 agent-desktop-core.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -906,6 +906,40 @@ AdResult ad_drag(const struct AdAdapter *adapter, const struct AdDragParams *par
 AdResult ad_mouse_event(const struct AdAdapter *adapter, const struct AdMouseEvent *event);
 
 /**
+ * Registers a callback to receive `tracing` events, or unregisters the
+ * current callback when `cb` is `NULL`.
+ *
+ * The subscriber layer is installed exactly once (the first time a non-null
+ * callback is set). Subsequent calls only swap the stored pointer, never
+ * re-install the layer.
+ *
+ * The callback receives:
+ * - `level` — 1 (ERROR) … 5 (TRACE)
+ * - `msg` — a NUL-terminated JSON string; valid only for the call's duration
+ *
+ * Sensitive field values (password, token, text, …) are replaced with
+ * `{"redacted":true}` before the message is formatted.
+ *
+ * Invocations are best-effort. A panicking callback is caught and silently
+ * discarded; no command fails because of a trace delivery error.
+ *
+ * # Safety
+ *
+ * `cb` must be null or a valid function pointer with the declared signature.
+ * The pointer is stored atomically; the subscriber may call it from threads
+ * other than the registering thread.
+ *
+ * A callback unregistered via `NULL` may still be invoked from another thread
+ * for a brief window after this call returns. The callback (and any data it
+ * captures) must remain valid for the process lifetime, or the caller must
+ * quiesce all tracing sources before unregistering.
+ *
+ * If a global tracing subscriber was already installed in the process before
+ * the first non-null registration, events may not be delivered.
+ */
+AdResult ad_set_log_callback(void (*cb)(int32_t level, const char *msg));
+
+/**
  * Triggers the named action on the notification at `index`. Typical
  * action names are those reported in `AdNotificationInfo.actions`
  * (e.g. `"Reply"`, `"Open"`).

--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -921,7 +921,9 @@ AdResult ad_mouse_event(const struct AdAdapter *adapter, const struct AdMouseEve
  * `{"redacted":true}` before the message is formatted.
  *
  * Invocations are best-effort. A panicking callback is caught and silently
- * discarded; no command fails because of a trace delivery error.
+ * discarded; no command fails because of a trace delivery error. A callback
+ * that emits `tracing` events is safe: the recursive `on_event` is dropped
+ * by a per-thread guard before it reaches the callback again.
  *
  * # Safety
  *

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -52,6 +52,7 @@ pub(crate) mod enum_validation;
 pub mod error;
 pub(crate) mod ffi_try;
 pub(crate) mod input;
+pub(crate) mod log_callback;
 pub(crate) mod main_thread;
 pub(crate) mod notifications;
 pub(crate) mod observation;

--- a/crates/ffi/src/log_callback.rs
+++ b/crates/ffi/src/log_callback.rs
@@ -1,0 +1,187 @@
+//! `ad_set_log_callback` — forward `tracing` events to a consumer callback.
+//!
+//! # Thread-safety
+//!
+//! `tracing` events fire from arbitrary threads. The callback pointer is
+//! stored in a global `AtomicPtr` (lock-free, reentrancy-safe). A
+//! `tracing_subscriber` layer is installed exactly once (via [`Once`]) when
+//! the first non-null callback is registered; subsequent registrations only
+//! swap the pointer.
+//!
+//! # Level mapping
+//!
+//! | `tracing` level | `level` passed to callback |
+//! |-----------------|---------------------------|
+//! | ERROR           | 1                         |
+//! | WARN            | 2                         |
+//! | INFO            | 3                         |
+//! | DEBUG           | 4                         |
+//! | TRACE           | 5                         |
+//!
+//! # Pointer lifetime
+//!
+//! The `msg` pointer passed to the callback is valid **only for the duration
+//! of the call**. The consumer must copy the string before returning.
+//!
+//! # Redaction
+//!
+//! Fields whose keys match `SENSITIVE_KEYS` (password, token, text, …) are
+//! replaced with `{"redacted":true}` before the message is formatted, using
+//! the same logic as the file-trace writer.
+
+use std::ffi::{CString, c_char};
+use std::os::raw::c_void;
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::sync::Once;
+use std::sync::atomic::{AtomicPtr, Ordering};
+
+use agent_desktop_core::trace::sanitize_trace_value;
+use serde_json::{Map, Value};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+use crate::error::AdResult;
+
+/// Raw storage for the consumer callback. Null means no callback registered.
+/// Stored as `*mut c_void` to avoid `fn` pointer restrictions on `AtomicPtr`.
+static CALLBACK_SLOT: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
+
+/// Installs the global subscriber exactly once.
+static INSTALL_ONCE: Once = Once::new();
+
+/// The concrete type of the consumer callback.
+type LogCb = unsafe extern "C" fn(level: i32, msg: *const c_char);
+
+/// Soundness guard: `fn` pointer and data pointer must be the same size so
+/// the `transmute` in `on_event` is layout-safe on every target.
+const _: () = assert!(
+    std::mem::size_of::<LogCb>() == std::mem::size_of::<*mut c_void>(),
+    "fn pointer size must equal data pointer size for LogCb transmute"
+);
+
+fn level_to_i32(level: &Level) -> i32 {
+    match *level {
+        Level::ERROR => 1,
+        Level::WARN => 2,
+        Level::INFO => 3,
+        Level::DEBUG => 4,
+        Level::TRACE => 5,
+    }
+}
+
+/// Collects event fields into a `serde_json::Map`.
+struct FieldCollector {
+    map: Map<String, Value>,
+}
+
+impl Visit for FieldCollector {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.map
+            .insert(field.name().to_owned(), Value::String(value.to_owned()));
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.map
+            .insert(field.name().to_owned(), Value::String(format!("{value:?}")));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.map.insert(field.name().to_owned(), Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.map.insert(field.name().to_owned(), Value::from(value));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.map.insert(field.name().to_owned(), Value::Bool(value));
+    }
+}
+
+/// `tracing_subscriber` layer that forwards events to the registered callback.
+struct CallbackLayer;
+
+impl<S: Subscriber> Layer<S> for CallbackLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let ptr = CALLBACK_SLOT.load(Ordering::Acquire);
+        if ptr.is_null() {
+            return;
+        }
+
+        let _ = catch_unwind(AssertUnwindSafe(|| {
+            let level_i32 = level_to_i32(event.metadata().level());
+
+            let mut collector = FieldCollector { map: Map::new() };
+            event.record(&mut collector);
+
+            let sanitized = sanitize_trace_value(Value::Object(collector.map));
+            let msg_str = serde_json::to_string(&sanitized).unwrap_or_default();
+
+            let Ok(c_msg) = CString::new(msg_str) else {
+                return;
+            };
+
+            let cb: LogCb = unsafe { std::mem::transmute(ptr) };
+            unsafe { cb(level_i32, c_msg.as_ptr()) };
+        }));
+    }
+}
+
+fn install_layer_once() {
+    INSTALL_ONCE.call_once(|| {
+        let registry = tracing_subscriber::registry().with(CallbackLayer);
+        let _ = registry.try_init();
+    });
+}
+
+/// Registers a callback to receive `tracing` events, or unregisters the
+/// current callback when `cb` is `NULL`.
+///
+/// The subscriber layer is installed exactly once (the first time a non-null
+/// callback is set). Subsequent calls only swap the stored pointer, never
+/// re-install the layer.
+///
+/// The callback receives:
+/// - `level` — 1 (ERROR) … 5 (TRACE)
+/// - `msg` — a NUL-terminated JSON string; valid only for the call's duration
+///
+/// Sensitive field values (password, token, text, …) are replaced with
+/// `{"redacted":true}` before the message is formatted.
+///
+/// Invocations are best-effort. A panicking callback is caught and silently
+/// discarded; no command fails because of a trace delivery error.
+///
+/// # Safety
+///
+/// `cb` must be null or a valid function pointer with the declared signature.
+/// The pointer is stored atomically; the subscriber may call it from threads
+/// other than the registering thread.
+///
+/// A callback unregistered via `NULL` may still be invoked from another thread
+/// for a brief window after this call returns. The callback (and any data it
+/// captures) must remain valid for the process lifetime, or the caller must
+/// quiesce all tracing sources before unregistering.
+///
+/// If a global tracing subscriber was already installed in the process before
+/// the first non-null registration, events may not be delivered.
+#[unsafe(no_mangle)]
+pub extern "C" fn ad_set_log_callback(
+    cb: Option<unsafe extern "C" fn(level: i32, msg: *const c_char)>,
+) -> AdResult {
+    crate::ffi_try::trap_panic(|| {
+        match cb {
+            Some(f) => {
+                install_layer_once();
+                let raw = f as *mut c_void;
+                CALLBACK_SLOT.store(raw, Ordering::Release);
+            }
+            None => {
+                CALLBACK_SLOT.store(std::ptr::null_mut(), Ordering::Release);
+            }
+        }
+        AdResult::Ok
+    })
+}

--- a/crates/ffi/src/log_callback.rs
+++ b/crates/ffi/src/log_callback.rs
@@ -3,10 +3,13 @@
 //! # Thread-safety
 //!
 //! `tracing` events fire from arbitrary threads. The callback pointer is
-//! stored in a global `AtomicPtr` (lock-free, reentrancy-safe). A
-//! `tracing_subscriber` layer is installed exactly once (via [`Once`]) when
-//! the first non-null callback is registered; subsequent registrations only
-//! swap the pointer.
+//! stored in a global `AtomicPtr` (lock-free). A `tracing_subscriber` layer
+//! is installed exactly once (via [`Once`]) when the first non-null callback
+//! is registered; subsequent registrations only swap the pointer.
+//!
+//! Re-entrancy is prevented by a per-thread flag: if a consumer callback
+//! itself emits a `tracing` event, the recursive `on_event` invocation is
+//! silently discarded rather than overflowing the stack.
 //!
 //! # Level mapping
 //!
@@ -29,13 +32,14 @@
 //! replaced with `{"redacted":true}` before the message is formatted, using
 //! the same logic as the file-trace writer.
 
+use std::cell::Cell;
 use std::ffi::{CString, c_char};
 use std::os::raw::c_void;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::sync::Once;
 use std::sync::atomic::{AtomicPtr, Ordering};
 
-use agent_desktop_core::trace::sanitize_trace_value;
+use agent_desktop_core::sanitize_trace_value;
 use serde_json::{Map, Value};
 use tracing::field::{Field, Visit};
 use tracing::{Event, Level, Subscriber};
@@ -51,6 +55,20 @@ static CALLBACK_SLOT: AtomicPtr<c_void> = AtomicPtr::new(std::ptr::null_mut());
 
 /// Installs the global subscriber exactly once.
 static INSTALL_ONCE: Once = Once::new();
+
+thread_local! {
+    static IN_CALLBACK: Cell<bool> = const { Cell::new(false) };
+}
+
+/// RAII guard that resets [`IN_CALLBACK`] on drop, so a panicking callback
+/// does not permanently poison the flag on its thread.
+struct CallbackGuard;
+
+impl Drop for CallbackGuard {
+    fn drop(&mut self) {
+        IN_CALLBACK.with(|g| g.set(false));
+    }
+}
 
 /// The concrete type of the consumer callback.
 type LogCb = unsafe extern "C" fn(level: i32, msg: *const c_char);
@@ -111,6 +129,10 @@ impl<S: Subscriber> Layer<S> for CallbackLayer {
             return;
         }
 
+        if IN_CALLBACK.with(Cell::get) {
+            return;
+        }
+
         let _ = catch_unwind(AssertUnwindSafe(|| {
             let level_i32 = level_to_i32(event.metadata().level());
 
@@ -124,7 +146,9 @@ impl<S: Subscriber> Layer<S> for CallbackLayer {
                 return;
             };
 
+            IN_CALLBACK.with(|g| g.set(true));
             let cb: LogCb = unsafe { std::mem::transmute(ptr) };
+            let _reset = CallbackGuard;
             unsafe { cb(level_i32, c_msg.as_ptr()) };
         }));
     }
@@ -152,7 +176,9 @@ fn install_layer_once() {
 /// `{"redacted":true}` before the message is formatted.
 ///
 /// Invocations are best-effort. A panicking callback is caught and silently
-/// discarded; no command fails because of a trace delivery error.
+/// discarded; no command fails because of a trace delivery error. A callback
+/// that emits `tracing` events is safe: the recursive `on_event` is dropped
+/// by a per-thread guard before it reaches the callback again.
 ///
 /// # Safety
 ///

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -5,9 +5,12 @@ use common::{
     ad_abi_version, ad_adapter_create, ad_adapter_create_with_session, ad_adapter_destroy,
     ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_find,
     ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
-    ad_list_apps, ad_list_windows, ad_version, ad_window_list_count, ad_window_list_free,
+    ad_list_apps, ad_list_windows, ad_set_log_callback, ad_version, ad_window_list_count,
+    ad_window_list_free,
     with_adapter,
 };
+use std::os::raw::c_char;
+use std::sync::Mutex;
 
 #[test]
 fn abi_version_matches_rust_constant() {
@@ -385,5 +388,190 @@ fn empty_session_returns_null_and_sets_invalid_args() {
         );
         let msg = ad_last_error_message();
         assert!(!msg.is_null(), "error message must be set on empty session");
+    }
+}
+
+/// Captured delivery from the test callback.
+struct Delivery {
+    level: i32,
+    message: String,
+}
+
+static RECORDER: Mutex<Vec<Delivery>> = Mutex::new(Vec::new());
+static LOG_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+/// Consumer-side recorder callback.  Must NOT emit tracing events (recursion).
+unsafe extern "C" fn recorder_cb(level: i32, msg: *const c_char) {
+    if msg.is_null() {
+        return;
+    }
+    let message = unsafe { CStr::from_ptr(msg) }
+        .to_string_lossy()
+        .into_owned();
+    if let Ok(mut guard) = RECORDER.lock() {
+        guard.push(Delivery { level, message });
+    }
+}
+
+fn clear_recorder() {
+    if let Ok(mut g) = RECORDER.lock() {
+        g.clear();
+    }
+}
+
+fn drain_recorder() -> Vec<Delivery> {
+    RECORDER
+        .lock()
+        .map(|mut g| g.drain(..).collect())
+        .unwrap_or_default()
+}
+
+/// Register callback → emit a tracing event → callback receives level + non-null message.
+#[test]
+fn log_callback_register_delivers_event() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    clear_recorder();
+
+    unsafe {
+        let rc = ad_set_log_callback(Some(recorder_cb));
+        assert_eq!(rc, AdResult::Ok, "register must succeed");
+    }
+
+    tracing::error!(
+        test_marker = "deliver_event",
+        "log_callback_register_delivers_event"
+    );
+
+    let deliveries = drain_recorder();
+    assert!(
+        !deliveries.is_empty(),
+        "at least one delivery expected after tracing::error!"
+    );
+    let d = deliveries
+        .iter()
+        .find(|d| d.message.contains("deliver_event"))
+        .unwrap_or(&deliveries[0]);
+    assert_eq!(d.level, 1, "ERROR maps to level 1");
+    assert!(!d.message.is_empty(), "message must be non-empty");
+
+    unsafe {
+        let _ = ad_set_log_callback(None);
+    }
+}
+
+/// A tracing event emitted from a spawned thread does not panic across the boundary.
+#[test]
+fn log_callback_spawned_thread_does_not_panic() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    clear_recorder();
+
+    unsafe {
+        let rc = ad_set_log_callback(Some(recorder_cb));
+        assert_eq!(rc, AdResult::Ok);
+    }
+
+    let handle = std::thread::spawn(|| {
+        tracing::warn!(
+            source = "spawned_thread",
+            "log_callback_spawned_thread_does_not_panic"
+        );
+    });
+    handle.join().expect("spawned thread must not panic");
+
+    let deliveries = drain_recorder();
+    assert!(
+        !deliveries.is_empty(),
+        "spawned-thread event must reach the callback"
+    );
+
+    unsafe {
+        let _ = ad_set_log_callback(None);
+    }
+}
+
+/// NULL unregisters the callback; subsequent events are not delivered.
+#[test]
+fn log_callback_null_unregisters() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    clear_recorder();
+
+    unsafe {
+        let _ = ad_set_log_callback(Some(recorder_cb));
+        let rc = ad_set_log_callback(None);
+        assert_eq!(rc, AdResult::Ok, "NULL unregister must succeed");
+    }
+
+    tracing::error!(test_marker = "after_null", "log_callback_null_unregisters");
+
+    let deliveries = drain_recorder();
+    assert!(
+        deliveries.is_empty(),
+        "no deliveries expected after NULL unregister, got {}",
+        deliveries.len()
+    );
+}
+
+/// A sensitive field (keyed by a SENSITIVE_KEYS name) is REDACTED in the
+/// delivered message; non-sensitive fields are preserved.
+#[test]
+fn log_callback_redacts_sensitive_fields() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    clear_recorder();
+
+    unsafe {
+        let rc = ad_set_log_callback(Some(recorder_cb));
+        assert_eq!(rc, AdResult::Ok);
+    }
+
+    tracing::error!(
+        password = "super_secret_password",
+        token = "bearer_xyz",
+        operation = "login_attempt",
+        "log_callback_redacts_sensitive_fields"
+    );
+
+    let deliveries = drain_recorder();
+    assert!(!deliveries.is_empty(), "expected at least one delivery");
+
+    let combined: String = deliveries
+        .iter()
+        .map(|d| d.message.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    assert!(
+        !combined.contains("super_secret_password"),
+        "raw password must not appear in callback message; got: {combined}"
+    );
+    assert!(
+        !combined.contains("bearer_xyz"),
+        "raw token must not appear in callback message; got: {combined}"
+    );
+    assert!(
+        combined.contains("redacted"),
+        "redaction marker must appear; got: {combined}"
+    );
+    assert!(
+        combined.contains("login_attempt"),
+        "non-sensitive field value must be preserved; got: {combined}"
+    );
+
+    unsafe {
+        let _ = ad_set_log_callback(None);
+    }
+}
+
+/// Re-registering a callback (and NULL then re-register) swaps the pointer
+/// without returning an error.
+#[test]
+fn log_callback_re_register_is_ok() {
+    let _guard = LOG_TEST_LOCK.lock().unwrap();
+    clear_recorder();
+
+    unsafe {
+        assert_eq!(ad_set_log_callback(Some(recorder_cb)), AdResult::Ok);
+        assert_eq!(ad_set_log_callback(None), AdResult::Ok);
+        assert_eq!(ad_set_log_callback(Some(recorder_cb)), AdResult::Ok);
+        assert_eq!(ad_set_log_callback(None), AdResult::Ok);
     }
 }

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -6,8 +6,7 @@ use common::{
     ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_find,
     ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
     ad_list_apps, ad_list_windows, ad_set_log_callback, ad_version, ad_window_list_count,
-    ad_window_list_free,
-    with_adapter,
+    ad_window_list_free, with_adapter,
 };
 use std::os::raw::c_char;
 use std::sync::Mutex;
@@ -500,6 +499,7 @@ fn log_callback_null_unregisters() {
         let rc = ad_set_log_callback(None);
         assert_eq!(rc, AdResult::Ok, "NULL unregister must succeed");
     }
+    clear_recorder();
 
     tracing::error!(test_marker = "after_null", "log_callback_null_unregisters");
 

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -15,6 +15,9 @@ unsafe extern "C" {
     pub fn ad_init(expected_major: u32) -> AdResult;
     pub fn ad_version(out: *mut *mut c_char) -> AdResult;
     pub fn ad_free_string(s: *mut c_char);
+    pub fn ad_set_log_callback(
+        cb: Option<unsafe extern "C" fn(level: i32, msg: *const c_char)>,
+    ) -> AdResult;
 
     pub fn ad_ref_entry_size() -> usize;
     pub fn ad_action_size() -> usize;


### PR DESCRIPTION
Adds `ad_set_log_callback` so dlopen consumers capture tracing output. Subscriber installed once (`Once`); swappable callback in an `AtomicPtr` (lock-free, reentrancy-safe); `catch_unwind`-guarded `on_event`; keyed redaction via the shared `sanitize_trace_value` so SENSITIVE_KEYS never reach the callback. The NULL-unregister lock-free lifetime contract is documented in the `# Safety` block + header.

---
Stacked on #67 (FFI header foundation). **Do not merge ahead of its base.** Phase A · Wave 1.

Gated locally against the full CI contract before opening: `fmt --check`, `clippy --locked -D warnings`, `cargo test --locked --lib --workspace` + `-p agent-desktop` + `-p agent-desktop-ffi --tests` (all 0 failed), and `ci` + `release-ffi` profile builds. Header carries the 19 `_Static_assert` guards + this unit's symbol.