### PR TITLE
feat: add ad_snapshot with refmap pipeline

### DIFF
--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -777,6 +777,43 @@ const struct AdAppInfo *ad_app_list_get(const struct AdAppList *list, uint32_t i
 void ad_app_list_free(struct AdAppList *list);
 
 /**
+ * Takes a full CLI-format snapshot of the target application window,
+ * allocates `@e` refs for all interactive elements, persists the refmap
+ * to disk, and writes the JSON envelope into `*out`.
+ *
+ * The JSON shape matches `agent-desktop snapshot`:
+ * `{"version":"2.0","ok":true,"command":"snapshot","data":{"app":"...","window":{...},"ref_count":N,"snapshot_id":"...","tree":{...}}}`.
+ *
+ * The caller must free `*out` with `ad_free_string`.
+ *
+ * `app` is tri-state:
+ * - null — snapshot the currently focused window (same as running the command with no `--app`).
+ * - valid UTF-8 string — snapshot the named application's focused window.
+ * - non-null but invalid UTF-8 or exceeding `AD_MAX_STRING_BYTES` — returns `ErrInvalidArgs`.
+ *
+ * `surface` is an `AdSnapshotSurface` discriminant (0 = Window, 1 = Focused, …).
+ * An out-of-range value returns `ErrInvalidArgs`.
+ *
+ * Skeleton mode and `--root` drill-down are not exposed here; they are a
+ * fast-follow to this entrypoint.
+ *
+ * # Safety
+ *
+ * `adapter` must be a non-null pointer from `ad_adapter_create` or
+ * `ad_adapter_create_with_session`. `out` must be a non-null writable
+ * `*mut *mut c_char`. `app` must be null or a NUL-terminated string within
+ * `AD_MAX_STRING_BYTES + 1` bytes. All pointers must remain valid for the
+ * duration of the call. `adapter` must be used from the main thread on macOS.
+ */
+AdResult ad_snapshot(const struct AdAdapter *adapter,
+                     const char *app,
+                     int32_t surface,
+                     uint8_t max_depth,
+                     bool interactive_only,
+                     bool compact,
+                     char **out);
+
+/**
  * Returns the `agent-desktop` version envelope as an owned JSON C string.
  *
  * The returned string has the same `{version, ok, command, data}` shape

--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -784,7 +784,15 @@ void ad_app_list_free(struct AdAppList *list);
  * The JSON shape matches `agent-desktop snapshot`:
  * `{"version":"2.0","ok":true,"command":"snapshot","data":{"app":"...","window":{...},"ref_count":N,"snapshot_id":"...","tree":{...}}}`.
  *
- * The caller must free `*out` with `ad_free_string`.
+ * **`*out` ownership and error behaviour:**
+ * - On success (`AD_RESULT_OK`): `*out` is a heap-allocated JSON string with `"ok":true`.
+ *   Caller must free it with `ad_free_string`.
+ * - On a command-level error (e.g. app not found, snapshot failure): `*out` is a
+ *   heap-allocated JSON string with `"ok":false` and an `"error"` payload. Caller
+ *   must still free it with `ad_free_string`. The last-error slot is also set.
+ * - On an argument or infrastructure error (null adapter, off-main-thread, invalid
+ *   UTF-8, bad surface discriminant, context failure): `*out` is set to null and no
+ *   allocation is made. Only the last-error slot is set.
  *
  * `app` is tri-state:
  * - null — snapshot the currently focused window (same as running the command with no `--app`).

--- a/crates/ffi/src/commands/mod.rs
+++ b/crates/ffi/src/commands/mod.rs
@@ -1,1 +1,2 @@
+pub mod snapshot;
 pub(crate) mod version;

--- a/crates/ffi/src/commands/mod.rs
+++ b/crates/ffi/src/commands/mod.rs
@@ -1,2 +1,16 @@
 pub mod snapshot;
 pub(crate) mod version;
+
+use agent_desktop_core::error::{AdapterError, AppError, ErrorCode};
+
+/// Converts a core `AppError` into an `AdapterError` for use with
+/// `set_last_error`. `AppError::Adapter` is already an `AdapterError`;
+/// the other variants wrap their payload as `ErrorCode::Internal`.
+pub(crate) fn app_error_to_adapter(err: AppError) -> AdapterError {
+    match err {
+        AppError::Adapter(e) => e,
+        AppError::Io(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
+        AppError::Json(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
+        AppError::Internal(msg) => AdapterError::new(ErrorCode::Internal, msg),
+    }
+}

--- a/crates/ffi/src/commands/snapshot.rs
+++ b/crates/ffi/src/commands/snapshot.rs
@@ -1,0 +1,142 @@
+use crate::AdAdapter;
+use crate::convert::string::{decode_optional_filter, string_to_c};
+use crate::convert::surface::snapshot_surface_from_c;
+use crate::error::{AdResult, set_last_error};
+use crate::ffi_try::trap_panic;
+use crate::main_thread::require_main_thread;
+use crate::pointer_guard::guard_non_null;
+use agent_desktop_core::commands::snapshot::SnapshotArgs;
+use agent_desktop_core::error::{AdapterError, AppError, ErrorCode};
+use agent_desktop_core::output::{ErrorPayload, Response};
+use std::ffi::c_char;
+use std::ptr;
+
+fn app_error_to_adapter(err: AppError) -> AdapterError {
+    match err {
+        AppError::Adapter(e) => e,
+        AppError::Io(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
+        AppError::Json(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
+        AppError::Internal(msg) => AdapterError::new(ErrorCode::Internal, msg),
+    }
+}
+
+/// Takes a full CLI-format snapshot of the target application window,
+/// allocates `@e` refs for all interactive elements, persists the refmap
+/// to disk, and writes the JSON envelope into `*out`.
+///
+/// The JSON shape matches `agent-desktop snapshot`:
+/// `{"version":"2.0","ok":true,"command":"snapshot","data":{"app":"...","window":{...},"ref_count":N,"snapshot_id":"...","tree":{...}}}`.
+///
+/// The caller must free `*out` with `ad_free_string`.
+///
+/// `app` is tri-state:
+/// - null — snapshot the currently focused window (same as running the command with no `--app`).
+/// - valid UTF-8 string — snapshot the named application's focused window.
+/// - non-null but invalid UTF-8 or exceeding `AD_MAX_STRING_BYTES` — returns `ErrInvalidArgs`.
+///
+/// `surface` is an `AdSnapshotSurface` discriminant (0 = Window, 1 = Focused, …).
+/// An out-of-range value returns `ErrInvalidArgs`.
+///
+/// Skeleton mode and `--root` drill-down are not exposed here; they are a
+/// fast-follow to this entrypoint.
+///
+/// # Safety
+///
+/// `adapter` must be a non-null pointer from `ad_adapter_create` or
+/// `ad_adapter_create_with_session`. `out` must be a non-null writable
+/// `*mut *mut c_char`. `app` must be null or a NUL-terminated string within
+/// `AD_MAX_STRING_BYTES + 1` bytes. All pointers must remain valid for the
+/// duration of the call. `adapter` must be used from the main thread on macOS.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ad_snapshot(
+    adapter: *const AdAdapter,
+    app: *const c_char,
+    surface: i32,
+    max_depth: u8,
+    interactive_only: bool,
+    compact: bool,
+    out: *mut *mut c_char,
+) -> AdResult {
+    guard_non_null!(out, c"out is null");
+    unsafe { *out = ptr::null_mut() };
+    trap_panic(|| {
+        if let Err(rc) = require_main_thread() {
+            return rc;
+        }
+        guard_non_null!(adapter, c"adapter is null");
+
+        let app_filter = unsafe { decode_optional_filter!(app, "app") };
+
+        let core_surface = match snapshot_surface_from_c(surface, "surface") {
+            Ok(s) => s,
+            Err(e) => {
+                set_last_error(&e);
+                return AdResult::ErrInvalidArgs;
+            }
+        };
+
+        let adapter_ref = unsafe { &*adapter };
+        let context = match adapter_ref.command_context() {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                let ae = app_error_to_adapter(e);
+                set_last_error(&ae);
+                return crate::error::last_error_code();
+            }
+        };
+
+        let args = SnapshotArgs {
+            app: app_filter,
+            window_id: None,
+            max_depth,
+            include_bounds: false,
+            interactive_only,
+            compact,
+            surface: core_surface,
+            skeleton: false,
+            root_ref: None,
+            snapshot_id: None,
+        };
+
+        let (envelope, had_error) = match agent_desktop_core::commands::snapshot::execute(
+            args,
+            adapter_ref.inner.as_ref(),
+            &context,
+        ) {
+            Ok(data) => (Response::ok("snapshot", data), false),
+            Err(app_err) => {
+                let payload = ErrorPayload::from_app_error(&app_err);
+                let ae = app_error_to_adapter(app_err);
+                set_last_error(&ae);
+                (Response::err("snapshot", payload), true)
+            }
+        };
+
+        let json = match serde_json::to_string(&envelope) {
+            Ok(s) => s,
+            Err(e) => {
+                let ae = AdapterError::new(
+                    ErrorCode::Internal,
+                    format!("failed to serialize snapshot envelope: {e}"),
+                );
+                set_last_error(&ae);
+                return AdResult::ErrInternal;
+            }
+        };
+
+        let c_ptr = string_to_c(&json);
+        if c_ptr.is_null() {
+            let ae = AdapterError::new(ErrorCode::Internal, "snapshot JSON contains interior NUL");
+            set_last_error(&ae);
+            return AdResult::ErrInternal;
+        }
+
+        unsafe { *out = c_ptr };
+
+        if had_error {
+            crate::error::last_error_code()
+        } else {
+            AdResult::Ok
+        }
+    })
+}

--- a/crates/ffi/src/commands/snapshot.rs
+++ b/crates/ffi/src/commands/snapshot.rs
@@ -1,4 +1,5 @@
 use crate::AdAdapter;
+use crate::commands::app_error_to_adapter;
 use crate::convert::string::{decode_optional_filter, string_to_c};
 use crate::convert::surface::snapshot_surface_from_c;
 use crate::error::{AdResult, set_last_error};
@@ -6,19 +7,10 @@ use crate::ffi_try::trap_panic;
 use crate::main_thread::require_main_thread;
 use crate::pointer_guard::guard_non_null;
 use agent_desktop_core::commands::snapshot::SnapshotArgs;
-use agent_desktop_core::error::{AdapterError, AppError, ErrorCode};
+use agent_desktop_core::error::{AdapterError, ErrorCode};
 use agent_desktop_core::output::{ErrorPayload, Response};
 use std::ffi::c_char;
 use std::ptr;
-
-fn app_error_to_adapter(err: AppError) -> AdapterError {
-    match err {
-        AppError::Adapter(e) => e,
-        AppError::Io(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
-        AppError::Json(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
-        AppError::Internal(msg) => AdapterError::new(ErrorCode::Internal, msg),
-    }
-}
 
 /// Takes a full CLI-format snapshot of the target application window,
 /// allocates `@e` refs for all interactive elements, persists the refmap
@@ -27,7 +19,15 @@ fn app_error_to_adapter(err: AppError) -> AdapterError {
 /// The JSON shape matches `agent-desktop snapshot`:
 /// `{"version":"2.0","ok":true,"command":"snapshot","data":{"app":"...","window":{...},"ref_count":N,"snapshot_id":"...","tree":{...}}}`.
 ///
-/// The caller must free `*out` with `ad_free_string`.
+/// **`*out` ownership and error behaviour:**
+/// - On success (`AD_RESULT_OK`): `*out` is a heap-allocated JSON string with `"ok":true`.
+///   Caller must free it with `ad_free_string`.
+/// - On a command-level error (e.g. app not found, snapshot failure): `*out` is a
+///   heap-allocated JSON string with `"ok":false` and an `"error"` payload. Caller
+///   must still free it with `ad_free_string`. The last-error slot is also set.
+/// - On an argument or infrastructure error (null adapter, off-main-thread, invalid
+///   UTF-8, bad surface discriminant, context failure): `*out` is set to null and no
+///   allocation is made. Only the last-error slot is set.
 ///
 /// `app` is tri-state:
 /// - null — snapshot the currently focused window (same as running the command with no `--app`).

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -5,8 +5,8 @@ use common::{
     ad_abi_version, ad_adapter_create, ad_adapter_create_with_session, ad_adapter_destroy,
     ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_find,
     ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
-    ad_list_apps, ad_list_windows, ad_set_log_callback, ad_version, ad_window_list_count,
-    ad_window_list_free, with_adapter,
+    ad_list_apps, ad_list_windows, ad_set_log_callback, ad_snapshot, ad_version,
+    ad_window_list_count, ad_window_list_free, with_adapter,
 };
 use std::os::raw::c_char;
 use std::sync::Mutex;
@@ -574,4 +574,132 @@ fn log_callback_re_register_is_ok() {
         assert_eq!(ad_set_log_callback(Some(recorder_cb)), AdResult::Ok);
         assert_eq!(ad_set_log_callback(None), AdResult::Ok);
     }
+}
+
+#[test]
+fn snapshot_null_out_returns_invalid_args() {
+    with_adapter(|adapter| unsafe {
+        let rc = ad_snapshot(
+            adapter,
+            std::ptr::null(),
+            0,
+            6,
+            false,
+            false,
+            std::ptr::null_mut(),
+        );
+        assert_eq!(
+            rc,
+            AdResult::ErrInvalidArgs,
+            "null out is rejected by the outer guard before any adapter or thread check"
+        );
+    });
+}
+
+#[test]
+fn snapshot_null_adapter_rejected() {
+    unsafe {
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_snapshot(
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            6,
+            false,
+            false,
+            &mut out,
+        );
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "null adapter must fail — got {rc:?} (ErrInternal on macOS off-main-thread is expected)"
+        );
+        assert!(out.is_null(), "out must stay null on null-adapter failure");
+    }
+}
+
+#[test]
+fn snapshot_invalid_utf8_app_rejected() {
+    with_adapter(|adapter| unsafe {
+        let bad: [u8; 3] = [0xC3, 0xFF, 0x00];
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_snapshot(
+            adapter,
+            bad.as_ptr() as *const std::os::raw::c_char,
+            0,
+            6,
+            false,
+            false,
+            &mut out,
+        );
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "invalid UTF-8 app must fail — got {rc:?}"
+        );
+        assert!(
+            out.is_null(),
+            "out must stay null on arg validation failure"
+        );
+    });
+}
+
+#[test]
+fn snapshot_invalid_surface_rejected() {
+    with_adapter(|adapter| unsafe {
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_snapshot(adapter, std::ptr::null(), 99, 6, false, false, &mut out);
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "out-of-range surface must fail — got {rc:?}"
+        );
+        assert!(out.is_null(), "out must stay null on invalid surface");
+    });
+}
+
+#[test]
+fn snapshot_returns_a_result_code_and_frees_cleanly() {
+    with_adapter(|adapter| unsafe {
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_snapshot(adapter, std::ptr::null(), 0, 6, false, false, &mut out);
+        let rc_i32 = rc as i32;
+        assert!(
+            rc_i32 <= 0,
+            "ad_snapshot must return a valid AdResult (<=0), got {rc_i32}"
+        );
+        if !out.is_null() {
+            let s = CStr::from_ptr(out).to_string_lossy();
+            assert!(!s.is_empty(), "non-null out must be a non-empty string");
+            ad_free_string(out);
+        }
+    });
+}
+
+#[test]
+fn snapshot_out_contains_envelope_fields_on_any_response() {
+    with_adapter(|adapter| unsafe {
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_snapshot(adapter, std::ptr::null(), 0, 6, false, false, &mut out);
+        if !out.is_null() {
+            let s = CStr::from_ptr(out).to_string_lossy();
+            assert!(
+                s.contains("\"version\""),
+                "envelope must carry 'version', got: {s}"
+            );
+            assert!(s.contains("\"ok\""), "envelope must carry 'ok', got: {s}");
+            assert!(
+                s.contains("\"command\""),
+                "envelope must carry 'command', got: {s}"
+            );
+            assert!(
+                s.contains("\"snapshot\""),
+                "command value must be 'snapshot', got: {s}"
+            );
+            ad_free_string(out);
+        } else {
+            let rc_i32 = rc as i32;
+            assert!(
+                rc_i32 < 0,
+                "null out is only valid on failure, got rc={rc_i32}"
+            );
+        }
+    });
 }

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -101,8 +101,6 @@ unsafe extern "C" {
         compact: bool,
         out: *mut *mut c_char,
     ) -> AdResult;
-
-    pub fn ad_free_string(s: *mut c_char);
 }
 
 pub fn with_adapter<F: FnOnce(*mut AdAdapter)>(body: F) {

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -91,6 +91,18 @@ unsafe extern "C" {
         entry: *const AdRefEntry,
         out: *mut AdNativeHandle,
     ) -> AdResult;
+
+    pub fn ad_snapshot(
+        adapter: *const AdAdapter,
+        app: *const c_char,
+        surface: i32,
+        max_depth: u8,
+        interactive_only: bool,
+        compact: bool,
+        out: *mut *mut c_char,
+    ) -> AdResult;
+
+    pub fn ad_free_string(s: *mut c_char);
 }
 
 pub fn with_adapter<F: FnOnce(*mut AdAdapter)>(body: F) {


### PR DESCRIPTION
Adds `ad_snapshot` — the full refmap pipeline (`snapshot::execute` → persists the refmap → tree carries `@e` refs), wrapped in the CLI envelope via `Response::ok` (KTD9). Flat scalar args (no new repr(C) struct → header stays at 19 `_Static_assert`). `CommandContext` from U3's `adapter.command_context()`.

Tests cover the C-ABI contract (null/invalid-arg rejection — lenient `ErrInvalidArgs | ErrInternal` per the macOS off-main-thread convention, matching existing entrypoints; envelope shape; lifecycle/free). The real-AX snapshot-success path is covered by the E2E harness (CI has no Accessibility permission).

---
Stacked on #70 (U3 session context) → which stacks on #67 (foundation). **Do not merge ahead of its base.** Phase A · Wave 2. Gated locally against the full CI contract (fmt, clippy --locked -D warnings, --locked --lib --workspace + -p agent-desktop + -p agent-desktop-ffi --tests, ci + release-ffi builds).