### PR TITLE
feat: add ad_status FFI entrypoint

### DIFF
--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -25,5 +25,9 @@ agent-desktop-windows = { path = "../windows" }
 [target.'cfg(target_os = "linux")'.dependencies]
 agent-desktop-linux = { path = "../linux" }
 
+[dev-dependencies]
+serde_json.workspace = true
+agent-desktop-core.workspace = true
+
 [lints]
 workspace = true

--- a/crates/ffi/Cargo.toml
+++ b/crates/ffi/Cargo.toml
@@ -25,9 +25,5 @@ agent-desktop-windows = { path = "../windows" }
 [target.'cfg(target_os = "linux")'.dependencies]
 agent-desktop-linux = { path = "../linux" }
 
-[dev-dependencies]
-serde_json.workspace = true
-agent-desktop-core.workspace = true
-
 [lints]
 workspace = true

--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -822,6 +822,25 @@ AdResult ad_snapshot(const struct AdAdapter *adapter,
                      char **out);
 
 /**
+ * Returns the adapter's current health and permission state as a JSON
+ * envelope matching the `agent-desktop status` CLI output.
+ *
+ * `ad_status` does not query the accessibility tree; it reads the
+ * permission report and ref-store metadata only, so it is safe to call
+ * from any thread (unlike tree-traversal commands that require the
+ * macOS main thread). On success `*out` is a NUL-terminated,
+ * heap-allocated JSON string freed with `ad_free_string`. On error
+ * `*out` is left null and the last-error slot is populated.
+ *
+ * # Safety
+ *
+ * `adapter` must be a non-null pointer returned by `ad_adapter_create`
+ * that has not been destroyed. `out` must be a non-null writable
+ * `*mut *mut c_char`.
+ */
+AdResult ad_status(const struct AdAdapter *adapter, char **out);
+
+/**
  * Returns the `agent-desktop` version envelope as an owned JSON C string.
  *
  * The returned string has the same `{version, ok, command, data}` shape

--- a/crates/ffi/src/commands/mod.rs
+++ b/crates/ffi/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod snapshot;
+pub(crate) mod status;
 pub(crate) mod version;
 
 use agent_desktop_core::error::{AdapterError, AppError, ErrorCode};

--- a/crates/ffi/src/commands/status.rs
+++ b/crates/ffi/src/commands/status.rs
@@ -3,8 +3,18 @@ use crate::error::{self, AdResult};
 use crate::ffi_try::trap_panic;
 use crate::pointer_guard::guard_non_null;
 use agent_desktop_core::commands::status::execute_with_report_with_context;
+use agent_desktop_core::error::{AdapterError, AppError, ErrorCode};
 use agent_desktop_core::output::Response;
 use std::ffi::c_char;
+
+fn record_app_error(app_err: AppError, fallback: &str) -> AdResult {
+    let adapter_err = match app_err {
+        AppError::Adapter(e) => e,
+        _ => AdapterError::new(ErrorCode::Internal, fallback),
+    };
+    error::set_last_error(&adapter_err);
+    error::last_error_code()
+}
 
 /// Returns the adapter's current health and permission state as a JSON
 /// envelope matching the `agent-desktop status` CLI output.
@@ -27,6 +37,7 @@ pub unsafe extern "C" fn ad_status(
     out: *mut *mut c_char,
 ) -> AdResult {
     guard_non_null!(out, c"out is null");
+    unsafe { *out = std::ptr::null_mut() };
     guard_non_null!(adapter, c"adapter is null");
 
     trap_panic(|| {
@@ -34,36 +45,14 @@ pub unsafe extern "C" fn ad_status(
 
         let ctx = match adapter.command_context() {
             Ok(c) => c,
-            Err(app_err) => {
-                let adapter_err = match app_err {
-                    agent_desktop_core::error::AppError::Adapter(e) => e,
-                    _ => agent_desktop_core::error::AdapterError::new(
-                        agent_desktop_core::error::ErrorCode::Internal,
-                        "failed to build command context",
-                    ),
-                };
-                error::set_last_error(&adapter_err);
-                unsafe { *out = std::ptr::null_mut() };
-                return AdResult::ErrInternal;
-            }
+            Err(app_err) => return record_app_error(app_err, "failed to build command context"),
         };
 
         let report = adapter.inner.permission_report();
 
         let response = match execute_with_report_with_context(&*adapter.inner, &report, &ctx) {
             Ok(data) => Response::ok("status", data),
-            Err(app_err) => {
-                let adapter_err = match app_err {
-                    agent_desktop_core::error::AppError::Adapter(e) => e,
-                    _ => agent_desktop_core::error::AdapterError::new(
-                        agent_desktop_core::error::ErrorCode::Internal,
-                        "status command failed",
-                    ),
-                };
-                error::set_last_error(&adapter_err);
-                unsafe { *out = std::ptr::null_mut() };
-                return crate::error::last_error_code();
-            }
+            Err(app_err) => return record_app_error(app_err, "status command failed"),
         };
 
         let json = match serde_json::to_string(&response) {
@@ -73,7 +62,6 @@ pub unsafe extern "C" fn ad_status(
                     AdResult::ErrInternal,
                     c"failed to serialize status response",
                 );
-                unsafe { *out = std::ptr::null_mut() };
                 return AdResult::ErrInternal;
             }
         };
@@ -84,7 +72,6 @@ pub unsafe extern "C" fn ad_status(
                 AdResult::ErrInternal,
                 c"status response contained interior NUL",
             );
-            unsafe { *out = std::ptr::null_mut() };
             return AdResult::ErrInternal;
         }
 

--- a/crates/ffi/src/commands/status.rs
+++ b/crates/ffi/src/commands/status.rs
@@ -1,0 +1,94 @@
+use crate::convert::string::string_to_c;
+use crate::error::{self, AdResult};
+use crate::ffi_try::trap_panic;
+use crate::pointer_guard::guard_non_null;
+use agent_desktop_core::commands::status::execute_with_report_with_context;
+use agent_desktop_core::output::Response;
+use std::ffi::c_char;
+
+/// Returns the adapter's current health and permission state as a JSON
+/// envelope matching the `agent-desktop status` CLI output.
+///
+/// `ad_status` does not query the accessibility tree; it reads the
+/// permission report and ref-store metadata only, so it is safe to call
+/// from any thread (unlike tree-traversal commands that require the
+/// macOS main thread). On success `*out` is a NUL-terminated,
+/// heap-allocated JSON string freed with `ad_free_string`. On error
+/// `*out` is left null and the last-error slot is populated.
+///
+/// # Safety
+///
+/// `adapter` must be a non-null pointer returned by `ad_adapter_create`
+/// that has not been destroyed. `out` must be a non-null writable
+/// `*mut *mut c_char`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ad_status(
+    adapter: *const crate::AdAdapter,
+    out: *mut *mut c_char,
+) -> AdResult {
+    guard_non_null!(out, c"out is null");
+    guard_non_null!(adapter, c"adapter is null");
+
+    trap_panic(|| {
+        let adapter = unsafe { &*adapter };
+
+        let ctx = match adapter.command_context() {
+            Ok(c) => c,
+            Err(app_err) => {
+                let adapter_err = match app_err {
+                    agent_desktop_core::error::AppError::Adapter(e) => e,
+                    _ => agent_desktop_core::error::AdapterError::new(
+                        agent_desktop_core::error::ErrorCode::Internal,
+                        "failed to build command context",
+                    ),
+                };
+                error::set_last_error(&adapter_err);
+                unsafe { *out = std::ptr::null_mut() };
+                return AdResult::ErrInternal;
+            }
+        };
+
+        let report = adapter.inner.permission_report();
+
+        let response = match execute_with_report_with_context(&*adapter.inner, &report, &ctx) {
+            Ok(data) => Response::ok("status", data),
+            Err(app_err) => {
+                let adapter_err = match app_err {
+                    agent_desktop_core::error::AppError::Adapter(e) => e,
+                    _ => agent_desktop_core::error::AdapterError::new(
+                        agent_desktop_core::error::ErrorCode::Internal,
+                        "status command failed",
+                    ),
+                };
+                error::set_last_error(&adapter_err);
+                unsafe { *out = std::ptr::null_mut() };
+                return crate::error::last_error_code();
+            }
+        };
+
+        let json = match serde_json::to_string(&response) {
+            Ok(s) => s,
+            Err(_) => {
+                error::set_last_error_static(
+                    AdResult::ErrInternal,
+                    c"failed to serialize status response",
+                );
+                unsafe { *out = std::ptr::null_mut() };
+                return AdResult::ErrInternal;
+            }
+        };
+
+        let ptr = string_to_c(&json);
+        if ptr.is_null() {
+            error::set_last_error_static(
+                AdResult::ErrInternal,
+                c"status response contained interior NUL",
+            );
+            unsafe { *out = std::ptr::null_mut() };
+            return AdResult::ErrInternal;
+        }
+
+        unsafe { *out = ptr };
+        AdResult::Ok
+    })
+}

--- a/crates/ffi/src/lib.rs
+++ b/crates/ffi/src/lib.rs
@@ -17,7 +17,7 @@
 //! - `ad_abi_version` / `ad_init` (no adapter, no AX/Cocoa state)
 //! - `ad_adapter_create` / `ad_adapter_destroy`
 //! - `ad_last_error_*` readers
-//! - `ad_check_permissions` (process-wide query, no AX/Cocoa state)
+//! - `ad_check_permissions`, `ad_status` (permission + ref-store reads, no AX tree traversal)
 //! - All `ad_*_list_{count,get,free}` accessors and
 //!   `ad_image_buffer_*` accessors
 //! - `ad_release_window_fields`, `ad_free_handle`, `ad_free_tree`,

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -5,7 +5,7 @@ use common::{
     ad_abi_version, ad_adapter_create, ad_adapter_create_with_session, ad_adapter_destroy,
     ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_find,
     ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
-    ad_list_apps, ad_list_windows, ad_set_log_callback, ad_snapshot, ad_version,
+    ad_list_apps, ad_list_windows, ad_set_log_callback, ad_snapshot, ad_status, ad_version,
     ad_window_list_count, ad_window_list_free, with_adapter,
 };
 use std::os::raw::c_char;
@@ -701,5 +701,86 @@ fn snapshot_out_contains_envelope_fields_on_any_response() {
                 "null out is only valid on failure, got rc={rc_i32}"
             );
         }
+    });
+}
+
+#[test]
+fn status_null_adapter_returns_invalid_args() {
+    unsafe {
+        let mut out: *mut std::os::raw::c_char = 0xDEAD_BEEF as *mut std::os::raw::c_char;
+        let rc = ad_status(std::ptr::null(), &mut out);
+        assert_eq!(
+            rc,
+            AdResult::ErrInvalidArgs,
+            "null adapter must return ErrInvalidArgs"
+        );
+        assert!(
+            out.is_null(),
+            "dirty out-param must be zeroed before early return on null adapter"
+        );
+    }
+}
+
+#[test]
+fn status_null_out_returns_invalid_args() {
+    with_adapter(|adapter| unsafe {
+        let rc = ad_status(adapter, std::ptr::null_mut());
+        assert_eq!(
+            rc,
+            AdResult::ErrInvalidArgs,
+            "null out must return ErrInvalidArgs"
+        );
+    });
+}
+
+#[test]
+fn status_returns_ok_envelope_with_required_fields() {
+    with_adapter(|adapter| unsafe {
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_status(adapter, &mut out);
+        assert_eq!(rc, AdResult::Ok, "ad_status must return Ok");
+        assert!(!out.is_null(), "out must be non-null on success");
+
+        let json_str = CStr::from_ptr(out)
+            .to_str()
+            .expect("status output must be valid UTF-8");
+        let val: serde_json::Value =
+            serde_json::from_str(json_str).expect("status output must be valid JSON");
+
+        assert_eq!(
+            val["version"].as_str(),
+            Some(agent_desktop_core::output::ENVELOPE_VERSION),
+            "envelope version must match ENVELOPE_VERSION constant"
+        );
+        assert_eq!(val["ok"].as_bool(), Some(true), "ok must be true");
+        assert_eq!(
+            val["command"].as_str(),
+            Some("status"),
+            "command must be \"status\""
+        );
+
+        let data = &val["data"];
+        assert!(
+            data["platform"].is_string(),
+            "data.platform must be present"
+        );
+        assert!(data["version"].is_string(), "data.version must be present");
+        assert!(
+            data["permissions"].is_object(),
+            "data.permissions must be present"
+        );
+
+        ad_free_string(out);
+    });
+}
+
+#[test]
+fn status_free_string_cleans_up() {
+    with_adapter(|adapter| unsafe {
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_status(adapter, &mut out);
+        assert_eq!(rc, AdResult::Ok);
+        assert!(!out.is_null());
+        ad_free_string(out);
     });
 }

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -101,6 +101,7 @@ unsafe extern "C" {
         compact: bool,
         out: *mut *mut c_char,
     ) -> AdResult;
+    pub fn ad_status(adapter: *const AdAdapter, out: *mut *mut c_char) -> AdResult;
 }
 
 pub fn with_adapter<F: FnOnce(*mut AdAdapter)>(body: F) {


### PR DESCRIPTION
Adds `ad_status` — reports adapter health + permission state, wrapped in the CLI envelope via `Response::ok` (KTD9). Calls `permission_report()` inline + `status::execute_with_report_with_context` with the U3 `CommandContext`. No `require_main_thread` (reads only the permission report + ref-store metadata, never the AX tree — matches the `ad_check_permissions` precedent). Envelope version asserted via the `ENVELOPE_VERSION` constant (no bump — same shape as CLI status).

---
Stacked on #70 (U3 session context) → #67 (foundation). **Do not merge ahead of its base.** Phase A · Wave 2. Full-CI-gated locally.