### PR TITLE
feat: add ad_execute_by_ref with strict resolution

### DIFF
--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -857,6 +857,43 @@ const struct AdAppInfo *ad_app_list_get(const struct AdAppList *list, uint32_t i
 void ad_app_list_free(struct AdAppList *list);
 
 /**
+ * Drives a ref action (`@e5`, action) through the full strict-resolution
+ * ladder: `RefStore` load → `RefMap` lookup (→ `STALE_REF` on missing) →
+ * `resolve_element_strict` (→ `STALE_REF`/`AMBIGUOUS_TARGET`) → live
+ * actionability preflight → dispatch → handle release.
+ *
+ * Policy follows CLI parity (KTD6): `TypeText` actions default to
+ * `focus_fallback`; every other action defaults to `headless`. An explicit
+ * `policy` discriminant may *elevate* to headed but must not downgrade an
+ * action below its CLI base.
+ *
+ * `ref_id` tri-state: null → `ErrInvalidArgs`; non-null invalid UTF-8 →
+ * `ErrInvalidArgs`; valid UTF-8 but bad `@e{N}` format → `ErrInvalidArgs`.
+ *
+ * `policy` is an `AdPolicyKind` discriminant (0=Headless, 1=FocusFallback,
+ * 2=Headed). An out-of-range value returns `ErrInvalidArgs`. `Headless (0)`
+ * accepts the action's own CLI base (so `TypeText` still uses
+ * `focus_fallback`). `Headed (2)` opts in to cursor-based fallbacks.
+ *
+ * On success `*out` is set to a NUL-terminated JSON envelope (command
+ * `"execute_by_ref"`); free with `ad_free_string`. On error `*out` is
+ * zeroed and the last-error slot is populated.
+ *
+ * # Safety
+ *
+ * `adapter` must be a non-null pointer from `ad_adapter_create[_with_session]`.
+ * `ref_id` must be null or NUL-terminated within `AD_MAX_STRING_BYTES + 1`
+ * bytes. `action` must be a non-null pointer to a valid `AdAction`.
+ * `out` must be a non-null writable pointer. All pointers must remain valid
+ * for the duration of the call. Must be called from the main thread on macOS.
+ */
+AdResult ad_execute_by_ref(const struct AdAdapter *adapter,
+                           const char *ref_id,
+                           const struct AdAction *action,
+                           int32_t policy,
+                           char **out);
+
+/**
  * Takes a full CLI-format snapshot of the target application window,
  * allocates `@e` refs for all interactive elements, persists the refmap
  * to disk, and writes the JSON envelope into `*out`.
@@ -902,29 +939,6 @@ AdResult ad_snapshot(const struct AdAdapter *adapter,
                      char **out);
 
 /**
- * Runs `wait` with the given args, blocking the calling thread until the
- * condition is met or `timeout_ms` elapses.
- *
- * On success `*out` is set to a freshly allocated JSON string containing the
- * CLI-format wait envelope (`{version, ok, command, data}`). The caller must
- * release the string with `ad_free_string(*out)`.
- *
- * On failure `*out` is zeroed, the last-error slot is set, and a negative
- * `AdResult` code is returned.
- *
- * # Safety
- *
- * `adapter` must be a non-null pointer returned by `ad_adapter_create` that
- * has not been destroyed. `args` must be non-null and point to a valid
- * zero-initialized `AdWaitArgs`. `out` must be non-null and point to a
- * writable `*mut c_char`.
- *
- * All `*const c_char` fields inside `AdWaitArgs` must be null or point to
- * readable, NUL-terminated memory within `AD_MAX_STRING_BYTES + 1` bytes.
- */
-AdResult ad_wait(const struct AdAdapter *adapter, const struct AdWaitArgs *args, char **out);
-
-/**
  * Returns the adapter's current health and permission state as a JSON
  * envelope matching the `agent-desktop status` CLI output.
  *
@@ -956,6 +970,29 @@ AdResult ad_status(const struct AdAdapter *adapter, char **out);
  * `out` must be a non-null writable `*mut *mut c_char`.
  */
 AdResult ad_version(char **out);
+
+/**
+ * Runs `wait` with the given args, blocking the calling thread until the
+ * condition is met or `timeout_ms` elapses.
+ *
+ * On success `*out` is set to a freshly allocated JSON string containing the
+ * CLI-format wait envelope (`{version, ok, command, data}`). The caller must
+ * release the string with `ad_free_string(*out)`.
+ *
+ * On failure `*out` is zeroed, the last-error slot is set, and a negative
+ * `AdResult` code is returned.
+ *
+ * # Safety
+ *
+ * `adapter` must be a non-null pointer returned by `ad_adapter_create` that
+ * has not been destroyed. `args` must be non-null and point to a valid
+ * zero-initialized `AdWaitArgs`. `out` must be non-null and point to a
+ * writable `*mut c_char`.
+ *
+ * All `*const c_char` fields inside `AdWaitArgs` must be null or point to
+ * readable, NUL-terminated memory within `AD_MAX_STRING_BYTES + 1` bytes.
+ */
+AdResult ad_wait(const struct AdAdapter *adapter, const struct AdWaitArgs *args, char **out);
 
 /**
  * Last-error lifetime — errno-style.

--- a/crates/ffi/include/agent_desktop.h
+++ b/crates/ffi/include/agent_desktop.h
@@ -876,8 +876,11 @@ void ad_app_list_free(struct AdAppList *list);
  * `focus_fallback`). `Headed (2)` opts in to cursor-based fallbacks.
  *
  * On success `*out` is set to a NUL-terminated JSON envelope (command
- * `"execute_by_ref"`); free with `ad_free_string`. On error `*out` is
- * zeroed and the last-error slot is populated.
+ * `"execute_by_ref"`); free with `ad_free_string`. On guard or decode
+ * failure (invalid args before the command runs) `*out` remains null.
+ * On a command-level error (STALE_REF, AMBIGUOUS_TARGET, etc.) `*out`
+ * holds the error JSON envelope and must still be freed with
+ * `ad_free_string`. The last-error slot is populated on all failures.
  *
  * # Safety
  *

--- a/crates/ffi/src/commands/execute_by_ref.rs
+++ b/crates/ffi/src/commands/execute_by_ref.rs
@@ -1,6 +1,7 @@
 use crate::AdAdapter;
 use crate::actions::conversion::action_from_c;
-use crate::convert::string::{CStrDecodeError, string_to_c, try_c_to_string};
+use crate::commands::app_error_to_adapter;
+use crate::convert::string::{required_adapter_string, string_to_c};
 use crate::error::{AdResult, set_last_error};
 use crate::ffi_try::trap_panic;
 use crate::main_thread::require_main_thread;
@@ -33,8 +34,11 @@ use std::ptr;
 /// `focus_fallback`). `Headed (2)` opts in to cursor-based fallbacks.
 ///
 /// On success `*out` is set to a NUL-terminated JSON envelope (command
-/// `"execute_by_ref"`); free with `ad_free_string`. On error `*out` is
-/// zeroed and the last-error slot is populated.
+/// `"execute_by_ref"`); free with `ad_free_string`. On guard or decode
+/// failure (invalid args before the command runs) `*out` remains null.
+/// On a command-level error (STALE_REF, AMBIGUOUS_TARGET, etc.) `*out`
+/// holds the error JSON envelope and must still be freed with
+/// `ad_free_string`. The last-error slot is populated on all failures.
 ///
 /// # Safety
 ///
@@ -60,27 +64,10 @@ pub unsafe extern "C" fn ad_execute_by_ref(
         guard_non_null!(adapter, c"adapter is null");
         guard_non_null!(action, c"action is null");
 
-        let ref_str = match unsafe { try_c_to_string(ref_id) } {
-            Ok(None) => {
-                set_last_error(&AdapterError::new(
-                    ErrorCode::InvalidArgs,
-                    "ref_id is null — must be a valid @e{N} ref string",
-                ));
-                return AdResult::ErrInvalidArgs;
-            }
-            Ok(Some(s)) => s,
-            Err(CStrDecodeError::NotUtf8) => {
-                set_last_error(&AdapterError::new(
-                    ErrorCode::InvalidArgs,
-                    "ref_id is not valid UTF-8",
-                ));
-                return AdResult::ErrInvalidArgs;
-            }
-            Err(CStrDecodeError::TooLong) => {
-                set_last_error(&AdapterError::new(
-                    ErrorCode::InvalidArgs,
-                    "ref_id exceeds AD_MAX_STRING_BYTES",
-                ));
+        let ref_str = match required_adapter_string(ref_id, "ref_id") {
+            Ok(s) => s,
+            Err(e) => {
+                set_last_error(&e);
                 return AdResult::ErrInvalidArgs;
             }
         };
@@ -88,7 +75,7 @@ pub unsafe extern "C" fn ad_execute_by_ref(
         if let Err(app_err) = validate_ref_id(&ref_str) {
             let ae = app_error_to_adapter(app_err);
             set_last_error(&ae);
-            return AdResult::ErrInvalidArgs;
+            return crate::error::last_error_code();
         }
 
         let caller_policy = match AdPolicyKind::from_c(policy) {
@@ -225,15 +212,6 @@ fn effective_action_policy(
         caller
     } else {
         base
-    }
-}
-
-fn app_error_to_adapter(err: AppError) -> AdapterError {
-    match err {
-        AppError::Adapter(e) => e,
-        AppError::Io(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
-        AppError::Json(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
-        AppError::Internal(msg) => AdapterError::new(ErrorCode::Internal, msg),
     }
 }
 

--- a/crates/ffi/src/commands/execute_by_ref.rs
+++ b/crates/ffi/src/commands/execute_by_ref.rs
@@ -1,0 +1,281 @@
+use crate::AdAdapter;
+use crate::actions::conversion::action_from_c;
+use crate::convert::string::{CStrDecodeError, string_to_c, try_c_to_string};
+use crate::error::{AdResult, set_last_error};
+use crate::ffi_try::trap_panic;
+use crate::main_thread::require_main_thread;
+use crate::pointer_guard::guard_non_null;
+use crate::types::{AdAction, AdPolicyKind};
+use agent_desktop_core::action_request::ActionRequest;
+use agent_desktop_core::error::{AdapterError, AppError, ErrorCode};
+use agent_desktop_core::output::{ErrorPayload, Response};
+use agent_desktop_core::refs::validate_ref_id;
+use agent_desktop_core::refs_store::RefStore;
+use std::ffi::c_char;
+use std::ptr;
+
+/// Drives a ref action (`@e5`, action) through the full strict-resolution
+/// ladder: `RefStore` load → `RefMap` lookup (→ `STALE_REF` on missing) →
+/// `resolve_element_strict` (→ `STALE_REF`/`AMBIGUOUS_TARGET`) → live
+/// actionability preflight → dispatch → handle release.
+///
+/// Policy follows CLI parity (KTD6): `TypeText` actions default to
+/// `focus_fallback`; every other action defaults to `headless`. An explicit
+/// `policy` discriminant may *elevate* to headed but must not downgrade an
+/// action below its CLI base.
+///
+/// `ref_id` tri-state: null → `ErrInvalidArgs`; non-null invalid UTF-8 →
+/// `ErrInvalidArgs`; valid UTF-8 but bad `@e{N}` format → `ErrInvalidArgs`.
+///
+/// `policy` is an `AdPolicyKind` discriminant (0=Headless, 1=FocusFallback,
+/// 2=Headed). An out-of-range value returns `ErrInvalidArgs`. `Headless (0)`
+/// accepts the action's own CLI base (so `TypeText` still uses
+/// `focus_fallback`). `Headed (2)` opts in to cursor-based fallbacks.
+///
+/// On success `*out` is set to a NUL-terminated JSON envelope (command
+/// `"execute_by_ref"`); free with `ad_free_string`. On error `*out` is
+/// zeroed and the last-error slot is populated.
+///
+/// # Safety
+///
+/// `adapter` must be a non-null pointer from `ad_adapter_create[_with_session]`.
+/// `ref_id` must be null or NUL-terminated within `AD_MAX_STRING_BYTES + 1`
+/// bytes. `action` must be a non-null pointer to a valid `AdAction`.
+/// `out` must be a non-null writable pointer. All pointers must remain valid
+/// for the duration of the call. Must be called from the main thread on macOS.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn ad_execute_by_ref(
+    adapter: *const AdAdapter,
+    ref_id: *const c_char,
+    action: *const AdAction,
+    policy: i32,
+    out: *mut *mut c_char,
+) -> AdResult {
+    guard_non_null!(out, c"out is null");
+    unsafe { *out = ptr::null_mut() };
+    trap_panic(|| {
+        if let Err(rc) = require_main_thread() {
+            return rc;
+        }
+        guard_non_null!(adapter, c"adapter is null");
+        guard_non_null!(action, c"action is null");
+
+        let ref_str = match unsafe { try_c_to_string(ref_id) } {
+            Ok(None) => {
+                set_last_error(&AdapterError::new(
+                    ErrorCode::InvalidArgs,
+                    "ref_id is null — must be a valid @e{N} ref string",
+                ));
+                return AdResult::ErrInvalidArgs;
+            }
+            Ok(Some(s)) => s,
+            Err(CStrDecodeError::NotUtf8) => {
+                set_last_error(&AdapterError::new(
+                    ErrorCode::InvalidArgs,
+                    "ref_id is not valid UTF-8",
+                ));
+                return AdResult::ErrInvalidArgs;
+            }
+            Err(CStrDecodeError::TooLong) => {
+                set_last_error(&AdapterError::new(
+                    ErrorCode::InvalidArgs,
+                    "ref_id exceeds AD_MAX_STRING_BYTES",
+                ));
+                return AdResult::ErrInvalidArgs;
+            }
+        };
+
+        if let Err(app_err) = validate_ref_id(&ref_str) {
+            let ae = app_error_to_adapter(app_err);
+            set_last_error(&ae);
+            return AdResult::ErrInvalidArgs;
+        }
+
+        let caller_policy = match AdPolicyKind::from_c(policy) {
+            Some(p) => p,
+            None => {
+                set_last_error(&AdapterError::new(
+                    ErrorCode::InvalidArgs,
+                    "invalid policy kind discriminant",
+                ));
+                return AdResult::ErrInvalidArgs;
+            }
+        };
+
+        let core_action = match unsafe { action_from_c(&*action) } {
+            Ok(a) => a,
+            Err(msg) => {
+                set_last_error(&AdapterError::new(ErrorCode::InvalidArgs, msg));
+                return AdResult::ErrInvalidArgs;
+            }
+        };
+
+        let effective_policy = effective_action_policy(&core_action, caller_policy);
+
+        let adapter_ref = unsafe { &*adapter };
+        let context = match adapter_ref.command_context() {
+            Ok(ctx) => ctx,
+            Err(e) => {
+                let ae = app_error_to_adapter(e);
+                set_last_error(&ae);
+                return crate::error::last_error_code();
+            }
+        };
+
+        let result = run_ref_action(
+            adapter_ref,
+            &ref_str,
+            context.session_id(),
+            effective_policy,
+            core_action,
+        );
+
+        let (envelope, had_error) = match result {
+            Ok(data) => (Response::ok("execute_by_ref", data), false),
+            Err(app_err) => {
+                let payload = ErrorPayload::from_app_error(&app_err);
+                let ae = app_error_to_adapter(app_err);
+                set_last_error(&ae);
+                (Response::err("execute_by_ref", payload), true)
+            }
+        };
+
+        let json = match serde_json::to_string(&envelope) {
+            Ok(s) => s,
+            Err(e) => {
+                let ae = AdapterError::new(
+                    ErrorCode::Internal,
+                    format!("failed to serialize execute_by_ref envelope: {e}"),
+                );
+                set_last_error(&ae);
+                return AdResult::ErrInternal;
+            }
+        };
+
+        let c_ptr = string_to_c(&json);
+        if c_ptr.is_null() {
+            let ae = AdapterError::new(
+                ErrorCode::Internal,
+                "execute_by_ref JSON contains interior NUL",
+            );
+            set_last_error(&ae);
+            return AdResult::ErrInternal;
+        }
+
+        unsafe { *out = c_ptr };
+
+        if had_error {
+            crate::error::last_error_code()
+        } else {
+            AdResult::Ok
+        }
+    })
+}
+
+/// Loads the `RefEntry` for `ref_id` from the session's `RefStore`, then
+/// dispatches the action through `ref_action::execute_entry`.
+///
+/// Resolution ladder: `RefStore::for_session` → `store.load` →
+/// `refmap.get` → `STALE_REF` on miss → `execute_entry` (strict resolve →
+/// `STALE_REF`/`AMBIGUOUS_TARGET` → actionability → dispatch).
+fn run_ref_action(
+    adapter: &AdAdapter,
+    ref_id: &str,
+    session_id: Option<&str>,
+    policy: AdPolicyKind,
+    action: agent_desktop_core::action::Action,
+) -> Result<serde_json::Value, AppError> {
+    let store = RefStore::for_session(session_id)?;
+    let refmap = store.load(None)?;
+    let entry = match refmap.get(ref_id) {
+        Some(e) => e.clone(),
+        None => return Err(AppError::stale_ref(ref_id)),
+    };
+    let request = match policy {
+        AdPolicyKind::Headless => ActionRequest::headless(action),
+        AdPolicyKind::FocusFallback => ActionRequest::focus_fallback(action),
+        AdPolicyKind::Headed => ActionRequest::headed(action),
+    };
+    let result =
+        agent_desktop_core::ref_action::execute_entry(adapter.inner.as_ref(), &entry, request)?;
+    Ok(serde_json::to_value(result)?)
+}
+
+/// Derive the effective interaction policy for this action (KTD6).
+///
+/// CLI base policies:
+/// - `TypeText` → `focus_fallback` (typing requires focus to land in the
+///   right field; headless would fail on unfocused elements).
+/// - Everything else → `headless` (pure AX action, no cursor movement).
+///
+/// The caller-supplied `policy` may *elevate* — passing `Headed` escalates
+/// to cursor + OS-input fallbacks — but never downgrades below the action's
+/// own base. `Headless (0)` accepts the action's base (so `TypeText` keeps
+/// `focus_fallback` rather than being degraded).
+fn effective_action_policy(
+    action: &agent_desktop_core::action::Action,
+    caller: AdPolicyKind,
+) -> AdPolicyKind {
+    use agent_desktop_core::action::Action;
+    let base = match action {
+        Action::TypeText(_) => AdPolicyKind::FocusFallback,
+        _ => AdPolicyKind::Headless,
+    };
+    if caller as i32 > base as i32 {
+        caller
+    } else {
+        base
+    }
+}
+
+fn app_error_to_adapter(err: AppError) -> AdapterError {
+    match err {
+        AppError::Adapter(e) => e,
+        AppError::Io(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
+        AppError::Json(e) => AdapterError::new(ErrorCode::Internal, e.to_string()),
+        AppError::Internal(msg) => AdapterError::new(ErrorCode::Internal, msg),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_desktop_core::action::Action;
+
+    #[test]
+    fn type_text_base_is_focus_fallback() {
+        let result =
+            effective_action_policy(&Action::TypeText("hello".into()), AdPolicyKind::Headless);
+        assert_eq!(result, AdPolicyKind::FocusFallback);
+    }
+
+    #[test]
+    fn click_base_is_headless() {
+        let result = effective_action_policy(&Action::Click, AdPolicyKind::Headless);
+        assert_eq!(result, AdPolicyKind::Headless);
+    }
+
+    #[test]
+    fn headed_caller_elevates_above_click_base() {
+        let result = effective_action_policy(&Action::Click, AdPolicyKind::Headed);
+        assert_eq!(result, AdPolicyKind::Headed);
+    }
+
+    #[test]
+    fn headed_caller_also_elevates_type_text() {
+        let result = effective_action_policy(&Action::TypeText("x".into()), AdPolicyKind::Headed);
+        assert_eq!(result, AdPolicyKind::Headed);
+    }
+
+    #[test]
+    fn headless_caller_cannot_downgrade_type_text() {
+        let result = effective_action_policy(&Action::TypeText("x".into()), AdPolicyKind::Headless);
+        assert_eq!(result, AdPolicyKind::FocusFallback);
+    }
+
+    #[test]
+    fn focus_fallback_caller_elevates_click() {
+        let result = effective_action_policy(&Action::Click, AdPolicyKind::FocusFallback);
+        assert_eq!(result, AdPolicyKind::FocusFallback);
+    }
+}

--- a/crates/ffi/src/commands/mod.rs
+++ b/crates/ffi/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod execute_by_ref;
 pub mod snapshot;
 pub(crate) mod status;
 pub(crate) mod version;

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -3,7 +3,7 @@ mod common;
 use common::{
     AdAppList, AdFindQuery, AdNativeHandle, AdResult, AdWaitArgs, AdWindowInfo, AdWindowList, CStr,
     ad_abi_version, ad_adapter_create, ad_adapter_create_with_session, ad_adapter_destroy,
-    ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_find,
+    ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_execute_by_ref, ad_find,
     ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
     ad_list_apps, ad_list_windows, ad_set_log_callback, ad_snapshot, ad_status, ad_version,
     ad_wait, ad_window_list_count, ad_window_list_free, with_adapter,
@@ -884,6 +884,127 @@ fn ad_wait_ms_mode_returns_ok_or_off_thread_error() {
                 );
             }
             other => panic!("unexpected result from ms-mode ad_wait: {:?}", other),
+        }
+    });
+}
+
+#[test]
+fn execute_by_ref_null_out_returns_invalid_args() {
+    with_adapter(|adapter| unsafe {
+        let ref_id = std::ffi::CString::new("@e1").unwrap();
+        let action = common::default_action();
+        let rc = ad_execute_by_ref(adapter, ref_id.as_ptr(), &action, 0, std::ptr::null_mut());
+        assert_eq!(
+            rc,
+            AdResult::ErrInvalidArgs,
+            "null out is rejected by the outer guard before any thread or adapter check"
+        );
+    });
+}
+
+#[test]
+fn execute_by_ref_null_adapter_rejected() {
+    unsafe {
+        let ref_id = std::ffi::CString::new("@e1").unwrap();
+        let action = common::default_action();
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_execute_by_ref(std::ptr::null(), ref_id.as_ptr(), &action, 0, &mut out);
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "null adapter must fail — got {rc:?} (ErrInternal on macOS off-main-thread is expected)"
+        );
+        assert!(out.is_null(), "out must stay null on failure");
+    }
+}
+
+#[test]
+fn execute_by_ref_null_ref_id_returns_invalid_args() {
+    with_adapter(|adapter| unsafe {
+        let action = common::default_action();
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_execute_by_ref(adapter, std::ptr::null(), &action, 0, &mut out);
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "null ref_id must fail — got {rc:?}"
+        );
+        assert!(out.is_null(), "out must stay null on null ref_id");
+    });
+}
+
+#[test]
+fn execute_by_ref_invalid_utf8_ref_id_returns_invalid_args() {
+    with_adapter(|adapter| unsafe {
+        let bad: [u8; 3] = [0xC3, 0xFF, 0x00];
+        let action = common::default_action();
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_execute_by_ref(
+            adapter,
+            bad.as_ptr() as *const std::os::raw::c_char,
+            &action,
+            0,
+            &mut out,
+        );
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "invalid UTF-8 ref_id must fail — got {rc:?}"
+        );
+        assert!(out.is_null(), "out must stay null on invalid UTF-8 ref_id");
+    });
+}
+
+#[test]
+fn execute_by_ref_null_action_rejected() {
+    with_adapter(|adapter| unsafe {
+        let ref_id = std::ffi::CString::new("@e1").unwrap();
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_execute_by_ref(adapter, ref_id.as_ptr(), std::ptr::null(), 0, &mut out);
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "null action must fail — got {rc:?}"
+        );
+        assert!(out.is_null(), "out must stay null on null action");
+    });
+}
+
+#[test]
+fn execute_by_ref_invalid_ref_format_returns_invalid_args() {
+    with_adapter(|adapter| unsafe {
+        let bad_ref = std::ffi::CString::new("@e0").unwrap();
+        let action = common::default_action();
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_execute_by_ref(adapter, bad_ref.as_ptr(), &action, 0, &mut out);
+        assert!(
+            matches!(rc, AdResult::ErrInvalidArgs | AdResult::ErrInternal),
+            "bad ref format must fail — got {rc:?}"
+        );
+        assert!(out.is_null(), "out must stay null on bad ref format");
+    });
+}
+
+#[test]
+fn execute_by_ref_stale_ref_returns_error_when_no_refmap_exists() {
+    with_adapter(|adapter| unsafe {
+        let ref_id = std::ffi::CString::new("@e1").unwrap();
+        let action = common::default_action();
+        let mut out: *mut std::os::raw::c_char = std::ptr::null_mut();
+        let rc = ad_execute_by_ref(adapter, ref_id.as_ptr(), &action, 0, &mut out);
+        let rc_i32 = rc as i32;
+        assert!(
+            rc_i32 <= 0,
+            "must return a valid AdResult (<=0), got {rc_i32}"
+        );
+        if !out.is_null() {
+            let s = CStr::from_ptr(out).to_string_lossy();
+            assert!(
+                s.contains("\"version\""),
+                "envelope must carry 'version', got: {s}"
+            );
+            assert!(s.contains("\"ok\""), "envelope must carry 'ok', got: {s}");
+            assert!(
+                s.contains("\"command\""),
+                "envelope must carry 'command', got: {s}"
+            );
+            ad_free_string(out);
         }
     });
 }

--- a/crates/ffi/tests/c_abi_lifecycle.rs
+++ b/crates/ffi/tests/c_abi_lifecycle.rs
@@ -3,8 +3,8 @@ mod common;
 use common::{
     AdAppList, AdFindQuery, AdNativeHandle, AdResult, AdWaitArgs, AdWindowInfo, AdWindowList, CStr,
     ad_abi_version, ad_adapter_create, ad_adapter_create_with_session, ad_adapter_destroy,
-    ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_execute_by_ref, ad_find,
-    ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
+    ad_app_list_count, ad_app_list_free, ad_app_list_get, ad_check_permissions, ad_execute_by_ref,
+    ad_find, ad_free_handle, ad_free_string, ad_init, ad_last_error_code, ad_last_error_message,
     ad_list_apps, ad_list_windows, ad_set_log_callback, ad_snapshot, ad_status, ad_version,
     ad_wait, ad_window_list_count, ad_window_list_free, with_adapter,
 };
@@ -982,7 +982,7 @@ fn execute_by_ref_invalid_ref_format_returns_invalid_args() {
 }
 
 #[test]
-fn execute_by_ref_stale_ref_returns_error_when_no_refmap_exists() {
+fn execute_by_ref_returns_error_envelope_when_no_refmap_exists() {
     with_adapter(|adapter| unsafe {
         let ref_id = std::ffi::CString::new("@e1").unwrap();
         let action = common::default_action();

--- a/crates/ffi/tests/common/mod.rs
+++ b/crates/ffi/tests/common/mod.rs
@@ -109,6 +109,15 @@ unsafe extern "C" {
         out: *mut *mut c_char,
     ) -> AdResult;
     pub fn ad_status(adapter: *const AdAdapter, out: *mut *mut c_char) -> AdResult;
+
+    pub fn ad_execute_by_ref(
+        adapter: *const AdAdapter,
+        ref_id: *const c_char,
+        action: *const AdAction,
+        policy: i32,
+        out: *mut *mut c_char,
+    ) -> AdResult;
+
 }
 
 pub fn with_adapter<F: FnOnce(*mut AdAdapter)>(body: F) {


### PR DESCRIPTION
Adds `ad_execute_by_ref(adapter, ref_id, action, policy, out)` — resolves a `@e` ref-id through the same strict-resolution ladder the CLI uses (`RefStore::for_session` → `refmap.get` → STALE_REF on miss → `ref_action::execute_entry`, which does the live strict-resolve / actionability preflight / dispatch / handle-release internally), then acts.

**Policy parity (KTD6):** the action's CLI base policy applies — `TypeText` → focus_fallback, every other action → headless. An explicit `AdPolicyKind` only *elevates* (max discriminant), never downgrades below the base.

Tests: null/invalid ref_id, null action/out/adapter → lenient `ErrInvalidArgs | ErrInternal`; stale-ref path. Successful real-AX actions are covered by the E2E harness.

---
Stacked on #72 (U4 snapshot) → #70 (U3) → #67 (foundation). **Do not merge ahead of its base.** Phase A · Wave 3. Full-CI-gated locally (fmt, clippy --locked, --locked lib/bin/ffi tests, ci + release-ffi builds).