### PR TITLE
fix(macos): harden retained_handle null guard against release-only CFRetain(null)

### DIFF
--- a/crates/macos/src/tree/resolve_classify.rs
+++ b/crates/macos/src/tree/resolve_classify.rs
@@ -84,9 +84,11 @@ fn text_len(value: Option<&str>) -> usize {
 #[cfg(target_os = "macos")]
 fn retained_handle(candidate: AXElement) -> Result<NativeHandle, AdapterError> {
     use core_foundation::base::{CFRetain, CFTypeRef};
-    #[cfg(test)]
     if candidate.0.is_null() {
+        #[cfg(test)]
         return Ok(NativeHandle::null());
+        #[cfg(not(test))]
+        return Err(AdapterError::element_not_found("element"));
     }
     unsafe { CFRetain(candidate.0 as CFTypeRef) };
     Ok(unsafe { NativeHandle::from_ptr(candidate.0 as *const _) })


### PR DESCRIPTION
## What

Makes the null-pointer check in `retained_handle` (`crates/macos/src/tree/resolve_classify.rs`) **unconditional** instead of `#[cfg(test)]`-only.

## Why

Previously the null guard was compiled only in test builds. In a release build it was elided, so a null `AXElement` candidate reaching `retained_handle` would call `CFRetain(NULL)` — a program-terminating assertion failure on macOS.

Reachability was verified as **currently impossible**: a null `AXElement` normalizes to role `"unknown"`, and refs are only ever allocated to elements with real interactive roles, so a null candidate can never match a live `RefEntry`. This change is therefore defense-in-depth at a memory-safety trust boundary, not a fix for a live crash — but a `CFRetain` that aborts on null must never have its guard compiled out of the shipping binary.

## Change

- The null check now always compiles.
- Test builds keep the existing benign placeholder behavior (`Ok(NativeHandle::null())`) so unit tests that pass null `AXElement` stand-ins continue to exercise classification logic.
- Release builds return `ElementNotFound` for a null candidate instead of dereferencing it.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p agent-desktop-macos --all-targets -- -D warnings` — clean
- `cargo test --lib -p agent-desktop-macos` — 128 passed (incl. the null-placeholder resolve tests)