### PR TITLE
test: stop CI flakes from tight wall-clock deadlines

### DIFF
--- a/crates/core/src/commands/drag_occlusion_retry_tests.rs
+++ b/crates/core/src/commands/drag_occlusion_retry_tests.rs
@@ -114,7 +114,7 @@ fn drag_retries_transient_post_focus_occlusion_without_holding_lease() {
     let snapshot_id = cross_app_snapshot();
     let adapter = TransientOcclusionAdapter::new();
     let mut args = cross_app_args(snapshot_id);
-    args.timeout_ms = Some(500);
+    args.timeout_ms = Some(5_000);
 
     let value = execute(args, &adapter, &CommandContext::default().with_headed(true)).unwrap();
 

--- a/crates/core/src/commands/drag_tests.rs
+++ b/crates/core/src/commands/drag_tests.rs
@@ -275,7 +275,7 @@ fn positive_timeout_uses_stable_post_focus_drag_bounds() {
         height: 60.0,
     });
     let mut args = cross_app_args(snapshot_id);
-    args.timeout_ms = Some(500);
+    args.timeout_ms = Some(5_000);
 
     let value = execute(args, &adapter, &CommandContext::default().with_headed(true)).unwrap();
 

--- a/crates/core/src/commands/hover_preflight_tests.rs
+++ b/crates/core/src/commands/hover_preflight_tests.rs
@@ -161,7 +161,7 @@ fn headed_hover_retries_transient_post_focus_occlusion_without_holding_lease() {
         lease_held: std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     };
     let mut args = ref_args(snapshot_id);
-    args.timeout_ms = Some(500);
+    args.timeout_ms = Some(5_000);
 
     let value = execute(args, &adapter, &CommandContext::default().with_headed(true)).unwrap();
 

--- a/crates/core/src/commands/hover_tests.rs
+++ b/crates/core/src/commands/hover_tests.rs
@@ -199,7 +199,7 @@ fn positive_timeout_uses_stable_post_focus_hover_bounds() {
         height: 10.0,
     });
     let mut args = ref_args(snapshot_id);
-    args.timeout_ms = Some(500);
+    args.timeout_ms = Some(5_000);
 
     let value = execute(args, &adapter, &CommandContext::default().with_headed(true)).unwrap();
 

--- a/crates/core/src/commands/pointer_action_tests.rs
+++ b/crates/core/src/commands/pointer_action_tests.rs
@@ -131,7 +131,7 @@ fn terminal_stale_ref_is_preserved_after_retry_budget_expires() {
     let adapter = TerminalAfterRetryAdapter {
         bounds_reads: AtomicU32::new(0),
     };
-    let deadline = crate::Deadline::after(100).unwrap();
+    let deadline = crate::Deadline::after(5_000).unwrap();
 
     let err = match wait_for_point_with_deadline(
         point_args(&snapshot_id),
@@ -197,7 +197,7 @@ fn explicitly_retryable_app_unresponsive_recovers_within_shared_deadline() {
     let adapter = UnresponsiveThenReadyAdapter {
         resolve_calls: AtomicU32::new(0),
     };
-    let deadline = crate::Deadline::after(1_000).unwrap();
+    let deadline = crate::Deadline::after(5_000).unwrap();
 
     let resolved = wait_for_point_with_deadline(
         point_args(&snapshot_id),

--- a/crates/core/src/live_locator/resolve_query_hydration_tests.rs
+++ b/crates/core/src/live_locator/resolve_query_hydration_tests.rs
@@ -71,7 +71,7 @@ fn hydration_retry_preserves_failed_attempt_statistics() {
     };
     let request = LocatorResolveRequest {
         selection: LocatorSelection::Strict,
-        deadline: crate::Deadline::after(1_000).unwrap(),
+        deadline: crate::Deadline::after(5_000).unwrap(),
         max_raw_depth: 10,
         materialization: LocatorMaterialization::SelectedMatches,
     };

--- a/crates/core/src/live_locator/selected_hydration_churn_tests.rs
+++ b/crates/core/src/live_locator/selected_hydration_churn_tests.rs
@@ -203,7 +203,7 @@ fn role_query(role: &str) -> LocatorQuery {
 fn selected_request() -> LocatorResolveRequest {
     LocatorResolveRequest {
         selection: LocatorSelection::First,
-        deadline: crate::Deadline::after(500).unwrap(),
+        deadline: crate::Deadline::after(5_000).unwrap(),
         max_raw_depth: 50,
         materialization: LocatorMaterialization::SelectedMatches,
     }

--- a/crates/core/src/live_locator/selected_hydration_contract_tests.rs
+++ b/crates/core/src/live_locator/selected_hydration_contract_tests.rs
@@ -233,7 +233,7 @@ fn role_query() -> LocatorQuery {
 fn selected_request() -> LocatorResolveRequest {
     LocatorResolveRequest {
         selection: LocatorSelection::First,
-        deadline: crate::Deadline::after(500).unwrap(),
+        deadline: crate::Deadline::after(5_000).unwrap(),
         max_raw_depth: 50,
         materialization: LocatorMaterialization::SelectedMatches,
     }

--- a/crates/core/src/live_locator/selected_hydration_subtree_tests.rs
+++ b/crates/core/src/live_locator/selected_hydration_subtree_tests.rs
@@ -294,7 +294,7 @@ fn containment(positive: bool) -> ContainmentPredicate {
 fn request() -> LocatorResolveRequest {
     LocatorResolveRequest {
         selection: LocatorSelection::First,
-        deadline: crate::Deadline::after(500).unwrap(),
+        deadline: crate::Deadline::after(5_000).unwrap(),
         max_raw_depth: 10,
         materialization: LocatorMaterialization::SelectedMatches,
     }

--- a/crates/core/src/ref_action_exactly_once_tests.rs
+++ b/crates/core/src/ref_action_exactly_once_tests.rs
@@ -288,7 +288,7 @@ fn zero_timeout_is_an_explicit_single_attempt() {
 #[test]
 fn ambiguity_diagnostic_preserves_adapter_result_details() {
     let adapter = DispatchGuardAdapter::new("ambiguous", 0);
-    let result = execute(&adapter, 500).unwrap();
+    let result = execute(&adapter, 5_000).unwrap();
     assert_eq!(result.details.as_ref().unwrap()["mechanism"], "AXPress");
     assert_eq!(
         result.details.as_ref().unwrap()["transient_ambiguity"],

--- a/crates/core/src/ref_action_wait_unresponsive_tests.rs
+++ b/crates/core/src/ref_action_wait_unresponsive_tests.rs
@@ -52,7 +52,7 @@ fn auto_wait_retries_a_transiently_unresponsive_accessibility_service() {
             ref_id: "@e1",
             context: &CommandContext::default(),
         },
-        ActionRequest::headless(Action::Click).with_timeout_ms(Some(1_000)),
+        ActionRequest::headless(Action::Click).with_timeout_ms(Some(5_000)),
         crate::ref_action::dispatch_resolved,
     )
     .unwrap();

--- a/crates/core/src/renderer_accessibility_tests.rs
+++ b/crates/core/src/renderer_accessibility_tests.rs
@@ -88,7 +88,7 @@ fn activation_lease_is_dropped_before_observation_retry() {
         bounds: None,
         state: Default::default(),
     };
-    let deadline = crate::Deadline::after(500).unwrap();
+    let deadline = crate::Deadline::after(5_000).unwrap();
     let request = ObservationRequest::snapshot(&crate::TreeOptions::default(), deadline)
         .validate()
         .unwrap();


### PR DESCRIPTION
## Summary

A class of unit tests bounds real retry/resolve/hydration work with a tight wall-clock deadline (100–1000 ms) and asserts a definite outcome. On slow, contended GitHub macOS runners the work overran the budget and the test got a `Timeout` instead of its asserted outcome, flaking the `Test` job while every local run passed. Three had already surfaced on CI (`selected_hydration`, `drag_retries...occlusion`, `terminal_stale_ref...`).

This widens those budgets to the suite's existing 5 s idiom so the asserted state is reached deterministically. 13 sites across 12 test files; test-only, no production change.

Genuine deadline-**expiry** tests keep their tight budgets — permanently-unresolvable adapters, single-shot `timeout_ms 0`, deadline-value plumbing, and lock-contention tests all expire correctly regardless of runner speed, so widening them would be wrong (or slow) and they were left untouched.

## Verification

- `cargo test --lib -p agent-desktop-core` — 978 pass, 0 fail
- `cargo test --lib --workspace` — all suites pass
- `cargo fmt --all -- --check` — clean
- Diff is 13 one-for-one numeric budget swaps; no production code touched